### PR TITLE
feat: show artist images in search results

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Container } from '@/components/site/Container';
+import Image from 'next/image';
 import type { SpotifyArtist } from '@/types/common';
 
 export const dynamic = 'force-dynamic';
@@ -56,17 +57,31 @@ export default function HomePage() {
           />
           {results.length > 0 && (
             <ul className="w-full max-w-md border rounded-md bg-white">
-              {results.map((artist) => (
-                <li
-                  key={artist.id}
-                  onClick={() => setSelected(artist)}
-                  className={`px-4 py-2 cursor-pointer hover:bg-gray-100 ${
-                    selected?.id === artist.id ? 'bg-gray-200' : ''
-                  }`}
-                >
-                  {artist.name}
-                </li>
-              ))}
+              {results.map((artist) => {
+                const imageUrl = artist.images?.[0]?.url;
+                return (
+                  <li
+                    key={artist.id}
+                    onClick={() => setSelected(artist)}
+                    className={`flex items-center px-4 py-2 cursor-pointer hover:bg-gray-100 ${
+                      selected?.id === artist.id ? 'bg-gray-200' : ''
+                    }`}
+                  >
+                    {imageUrl ? (
+                      <Image
+                        src={imageUrl}
+                        alt={`${artist.name} profile photo`}
+                        width={40}
+                        height={40}
+                        className="w-10 h-10 rounded-full object-cover mr-3"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-gray-200 mr-3" />
+                    )}
+                    <span>{artist.name}</span>
+                  </li>
+                );
+              })}
             </ul>
           )}
           <Button onClick={handleClaim} disabled={!selected} size="lg">

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,4 @@
-import '@testing-library/jest-dom';
+import { expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);

--- a/tests/unit/Button.test.tsx
+++ b/tests/unit/Button.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { Button } from '@/components/ui/Button';
 
 describe('Button', () => {
+  afterEach(cleanup);
   it('renders correctly', () => {
     render(<Button>Click me</Button>);
     expect(


### PR DESCRIPTION
## Summary
- display artist profile photos next to names in homepage search results using Next.js `Image`
- configure testing utilities to extend matchers and clean up DOM between tests

## Testing
- `npx vitest run tests/unit`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_688e91037f4c8327b640252b2f760518