### PR TITLE
ci: add Lighthouse CI workflow with TTI budget

### DIFF
--- a/.github/workflows/web-lighthouse-ci.yml
+++ b/.github/workflows/web-lighthouse-ci.yml
@@ -1,0 +1,36 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [ dev ]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [ dev ]
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: http://localhost:3000
+          configPath: .lighthouserc.json
+          startServerCommand: npm start
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,9 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "interactive": ["error", { "maxNumericValue": 1500 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Lighthouse CI workflow
- enforce 1.5s time-to-interactive budget

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb5c9db1c8327a088b179bb27c9eb