### PR TITLE
chore: add next-sitemap for SEO assets

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_APP_URL || 'https://your-domain.com',
+  generateRobotsTxt: true,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "husky": "^9.1.7",
         "jsdom": "^23.1.0",
         "lint-staged": "^16.1.2",
+        "next-sitemap": "^4.2.3",
         "postcss": "^8",
         "prettier": "^3.1.1",
         "tailwindcss": "^4.1.11",
@@ -532,6 +533,13 @@
       "engines": {
         "node": ">=18.17.0"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
@@ -6415,7 +6423,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9129,6 +9136,41 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next-themes": {
       "version": "0.4.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "a11y:ci": "playwright test -g @a11y",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.28.1",
@@ -63,6 +64,7 @@
     "husky": "^9.1.7",
     "jsdom": "^23.1.0",
     "lint-staged": "^16.1.2",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8",
     "prettier": "^3.1.1",
     "tailwindcss": "^4.1.11",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://your-domain.com
+
+# Sitemaps
+Sitemap: https://your-domain.com/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://your-domain.com/robots.txt</loc><lastmod>2025-08-03T19:21:53.911Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://your-domain.com/sitemap.xml</loc><lastmod>2025-08-03T19:21:53.912Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://your-domain.com/manifest.webmanifest</loc><lastmod>2025-08-03T19:21:53.912Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://your-domain.com/sitemap-0.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
## Summary
- configure next-sitemap to emit sitemap.xml and robots.txt during builds
- generate initial sitemap and robots files for search engines

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb5d5b3a88327886f1f2547b05c6e