### PR TITLE
fix: render clerk waitlist

### DIFF
--- a/app/waitlist/page.tsx
+++ b/app/waitlist/page.tsx
@@ -17,7 +17,7 @@ export default function WaitlistPage() {
           </p>
 
           <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20">
-            <Waitlist />
+            <Waitlist signInUrl="/sign-in" />
           </div>
 
           <div className="mt-12 text-center">

--- a/components/providers/ClientProviders.tsx
+++ b/components/providers/ClientProviders.tsx
@@ -11,7 +11,7 @@ interface ClientProvidersProps {
 
 export function ClientProviders({ children }: ClientProvidersProps) {
   return (
-    <ClerkProvider>
+    <ClerkProvider clerkJSVersion="latest">
       <ThemeProvider
         attribute="class"
         defaultTheme="light"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
+      "next lint --fix --file",
       "prettier --write"
     ],
     "*.{json,md,css}": [


### PR DESCRIPTION
## Summary
- ensure Clerk prebuilt Waitlist component renders by forcing latest ClerkJS version
- wire Waitlist to sign-in URL for a smoother auth path
- use `next lint` in lint-staged pre-commit hook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc4173a0083279f4f479f3800190a