### PR TITLE
refactor: simplify home hero copy

### DIFF
--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -10,9 +10,6 @@ export function HomeHero() {
       role="banner"
       aria-labelledby="hero-headline"
     >
-      {/* Subtle gradient overlay for depth */}
-      <div className="absolute inset-0 bg-linear-to-b from-purple-50/5 to-transparent" />
-
       <Container className="relative flex max-w-4xl flex-col items-center text-center">
         {/* Hero Section - Above the fold */}
         <div className="mb-16 space-y-8">
@@ -35,18 +32,15 @@ export function HomeHero() {
             className="text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl"
           >
             <span className="block text-white">The fastest link-in-bio</span>
-            <span className="block bg-linear-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
-              Built for musicians
-            </span>
+            <span className="block text-accent">Built for musicians</span>
           </h1>
 
           {/* Subheadline - Tightened copy */}
           <p
-            className="mx-auto max-w-2xl text-xl text-white/80 sm:text-2xl leading-relaxed"
+            className="mx-auto max-w-2xl text-xl text-white sm:text-2xl leading-relaxed"
             role="doc-subtitle"
           >
-            One optimized profile loads instantly and converts
-            consistently—while others tweak colors, you gain streams.
+            One link. Every stream.
           </p>
         </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -91,20 +91,26 @@
   @apply h-10 px-4 py-2;
 }
 
-@utility btn-lg {
-  @apply h-12 px-8 text-base;
-}
-
-@layer base {
-  :root {
-    --background: 255 255 255;
-    --foreground: 17 24 39;
+  @utility btn-lg {
+    @apply h-12 px-8 text-base;
   }
 
-  .dark {
-    --background: 17 24 39;
-    --foreground: 249 250 251;
+  @utility text-accent {
+    color: rgb(var(--accent));
   }
+
+  @layer base {
+    :root {
+      --background: 255 255 255;
+      --foreground: 17 24 39;
+      --accent: 192 132 252;
+    }
+
+    .dark {
+      --background: 17 24 39;
+      --foreground: 249 250 251;
+      --accent: 192 132 252;
+    }
 
   body {
     @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-50;


### PR DESCRIPTION
## Summary
- streamline HomeHero headline and subheadline copy
- replace gradient headline styling with accent color variable
- add global accent utility and variable

## Testing
- `npm run lint`
- `npm test`
- `node -e "function luminance(r,g,b){r/=255;g/=255;b/=255;[r,g,b]=[r,g,b].map(c=>c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4));return 0.2126*r+0.7152*g+0.0722*b;} function contrast(a,b){return (Math.max(l1=luminance(...a),l2=luminance(...b))+0.05)/(Math.min(l1,l2)+0.05);} console.log('accent vs bg',contrast([192,132,252],[88,28,135]).toFixed(2)); console.log('white vs bg',contrast([255,255,255],[88,28,135]).toFixed(2));"`

------
https://chatgpt.com/codex/tasks/task_e_688fc927814083279fe5b798524dc92a