### PR TITLE
refactor: simplify floating elements container

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -143,10 +143,8 @@ export default function HomePage() {
         </div>
 
         {/* Floating Elements */}
-        <div className="absolute inset-0 overflow-hidden">
-          <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-linear-to-br from-indigo-500/20 to-purple-500/20 blur-3xl" />
-          <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-linear-to-tr from-pink-500/20 to-purple-500/20 blur-3xl" />
-        </div>
+        <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-linear-to-br from-indigo-500/20 to-purple-500/20 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-linear-to-tr from-pink-500/20 to-purple-500/20 blur-3xl" />
 
         {/* Hero Section */}
         <HomeHero />


### PR DESCRIPTION
## Summary
- remove redundant wrapper around floating background elements on marketing homepage

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688fc93c94fc832793068d69c6a60b81