### PR TITLE
refactor: streamline pre-footer cta

### DIFF
--- a/components/home/PreFooterCTA.tsx
+++ b/components/home/PreFooterCTA.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 export function PreFooterCTA() {
   return (
-    <section className="w-full bg-linear-to-br from-blue-600 via-purple-600 to-pink-600 py-24 px-4">
+    <section className="w-full bg-black py-24 sm:py-32 px-4 my-24 sm:my-32">
       <div className="max-w-2xl mx-auto text-center">
         <h2 className="text-4xl sm:text-5xl font-bold text-white mb-6">
           Stop losing fans to ugly link pages.
@@ -14,7 +14,7 @@ export function PreFooterCTA() {
         </p>
         <Link
           href="/sign-in"
-          className="inline-flex items-center justify-center rounded-full bg-white text-blue-700 hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-white/20 px-8 py-3 text-lg font-semibold transition-all duration-200 shadow-xs"
+          className="inline-flex items-center justify-center rounded-full bg-white text-black border-2 border-pink-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-pink-500 px-8 py-3 text-lg font-semibold transition-all duration-200 shadow-xs"
         >
           Get Your jov.ie Link
         </Link>


### PR DESCRIPTION
## Summary
- simplify PreFooterCTA with solid dark background and generous mobile spacing
- highlight call-to-action with single accent border

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fc94732508327b79c8453df67b932