### PR TITLE
feat: centralize accent colors

### DIFF
--- a/components/home/BenefitsSection.tsx
+++ b/components/home/BenefitsSection.tsx
@@ -1,70 +1,93 @@
-export function BenefitsSection() {
-  const benefits = [
-    {
-      title: 'Lightning Fast',
-      description: 'Loads 3× faster than customizable pages.',
-      icon: (
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M13 10V3L4 14h7v7l9-11h-7z"
-          />
-        </svg>
-      ),
-    },
-    {
-      title: 'Smart Preferences',
-      description: "Remembers every fan's favorite platform.",
-      icon: (
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-          />
-        </svg>
-      ),
-    },
-    {
-      title: 'Zero Distractions',
-      description: 'One design, no detours—pure music discovery.',
-      icon: (
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-          />
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-          />
-        </svg>
-      ),
-    },
-  ];
+type Benefit = {
+  title: string;
+  description: string;
+  icon: JSX.Element;
+  accent: React.CSSProperties;
+};
 
+const defaultBenefits: Benefit[] = [
+  {
+    title: 'Lightning Fast',
+    description: 'Loads 3× faster than customizable pages.',
+    accent: {
+      '--accent-500': 'var(--color-violet-500)',
+      '--accent-600': 'var(--color-violet-600)',
+    },
+    icon: (
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13 10V3L4 14h7v7l9-11h-7z"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: 'Smart Preferences',
+    description: "Remembers every fan's favorite platform.",
+    accent: {
+      '--accent-500': 'var(--color-violet-500)',
+      '--accent-600': 'var(--color-violet-600)',
+    },
+    icon: (
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: 'Zero Distractions',
+    description: 'One design, no detours—pure music discovery.',
+    accent: {
+      '--accent-500': 'var(--color-violet-500)',
+      '--accent-600': 'var(--color-violet-600)',
+    },
+    icon: (
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+        />
+      </svg>
+    ),
+  },
+];
+
+export function BenefitsSection({
+  benefits = defaultBenefits,
+}: {
+  benefits?: Benefit[];
+}) {
   return (
     <section className="relative bg-white py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
@@ -76,15 +99,19 @@ export function BenefitsSection() {
         <div className="mx-auto mt-20 max-w-6xl">
           <div className="grid grid-cols-1 gap-12 md:grid-cols-3">
             {benefits.map((benefit) => (
-              <div key={benefit.title} className="text-center">
-                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-violet-500 to-violet-600 text-white shadow-xs">
+              <div
+                key={benefit.title}
+                className="text-center"
+                style={benefit.accent}
+              >
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-[var(--accent-500)] to-[var(--accent-600)] text-white shadow-xs">
                   {benefit.icon}
                 </div>
                 <h3 className="mt-6 text-xl font-bold text-gray-900">
                   {benefit.title}
                 </h3>
-                {/* Violet accent dot */}
-                <div className="mx-auto mt-3 h-1 w-1 rounded-full bg-violet-500" />
+                {/* Accent dot */}
+                <div className="mx-auto mt-3 h-1 w-1 rounded-full bg-[var(--accent-500)]" />
                 <p className="mt-4 text-gray-600 leading-relaxed">
                   {benefit.description}
                 </p>

--- a/components/home/ComparisonSection.tsx
+++ b/components/home/ComparisonSection.tsx
@@ -1,25 +1,56 @@
-export function ComparisonSection() {
-  const features = [
-    {
-      feature: 'Customization Options',
-      others: 'Endless customization options',
-      jovie: 'One optimized design',
-      othersNegative: true,
-    },
-    {
-      feature: 'Loading Speed',
-      others: 'Slow loading',
-      jovie: 'Instant loading',
-      othersNegative: true,
-    },
-    {
-      feature: 'Target Audience',
-      others: 'Built for everyone',
-      jovie: 'Built for musicians only',
-      othersNegative: true,
-    },
-  ];
+type Feature = {
+  feature: string;
+  others: string;
+  jovie: string;
+  othersNegative?: boolean;
+};
 
+type Accent = React.CSSProperties;
+
+const defaultFeatures: Feature[] = [
+  {
+    feature: 'Customization Options',
+    others: 'Endless customization options',
+    jovie: 'One optimized design',
+    othersNegative: true,
+  },
+  {
+    feature: 'Loading Speed',
+    others: 'Slow loading',
+    jovie: 'Instant loading',
+    othersNegative: true,
+  },
+  {
+    feature: 'Target Audience',
+    others: 'Built for everyone',
+    jovie: 'Built for musicians only',
+    othersNegative: true,
+  },
+];
+
+const defaultOthersAccent: Accent = {
+  '--accent-25': 'var(--color-red-25)',
+  '--accent-50': 'var(--color-red-50)',
+  '--accent-900': 'var(--color-red-900)',
+};
+
+const defaultJovieAccent: Accent = {
+  '--accent-25': 'var(--color-blue-25)',
+  '--accent-50': 'var(--color-blue-50)',
+  '--accent-500': 'var(--color-blue-500)',
+  '--accent-700': 'var(--color-blue-700)',
+  '--accent-900': 'var(--color-blue-900)',
+};
+
+export function ComparisonSection({
+  features = defaultFeatures,
+  othersAccent = defaultOthersAccent,
+  jovieAccent = defaultJovieAccent,
+}: {
+  features?: Feature[];
+  othersAccent?: Accent;
+  jovieAccent?: Accent;
+}) {
   return (
     <section className="relative bg-gray-50 py-24 sm:py-32">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
@@ -35,13 +66,21 @@ export function ComparisonSection() {
               <div className="bg-gray-50 px-6 py-4">
                 <h3 className="text-lg font-semibold text-gray-900">Feature</h3>
               </div>
-              <div className="bg-red-50 px-6 py-4">
-                <h3 className="text-lg font-semibold text-red-900">
+              <div
+                style={othersAccent}
+                className="bg-[var(--accent-50)] px-6 py-4"
+              >
+                <h3 className="text-lg font-semibold text-[var(--accent-900)]">
                   Other Platforms
                 </h3>
               </div>
-              <div className="bg-blue-50 px-6 py-4">
-                <h3 className="text-lg font-semibold text-blue-900">Jovie</h3>
+              <div
+                style={jovieAccent}
+                className="bg-[var(--accent-50)] px-6 py-4"
+              >
+                <h3 className="text-lg font-semibold text-[var(--accent-900)]">
+                  Jovie
+                </h3>
               </div>
 
               {/* Features */}
@@ -53,7 +92,8 @@ export function ComparisonSection() {
                     <p className="font-medium text-gray-900">{item.feature}</p>
                   </div>
                   <div
-                    className={`px-6 py-3 ${index % 2 === 0 ? 'bg-red-25' : 'bg-red-50'}`}
+                    style={othersAccent}
+                    className={`px-6 py-3 ${index % 2 === 0 ? 'bg-[var(--accent-25)]' : 'bg-[var(--accent-50)]'}`}
                   >
                     <div className="flex items-center">
                       <svg
@@ -73,11 +113,12 @@ export function ComparisonSection() {
                     </div>
                   </div>
                   <div
-                    className={`px-6 py-3 ${index % 2 === 0 ? 'bg-blue-25' : 'bg-blue-50'}`}
+                    style={jovieAccent}
+                    className={`px-6 py-3 ${index % 2 === 0 ? 'bg-[var(--accent-25)]' : 'bg-[var(--accent-50)]'}`}
                   >
                     <div className="flex items-center">
                       <svg
-                        className="mr-3 h-4 w-4 text-blue-500"
+                        className="mr-3 h-4 w-4 text-[var(--accent-500)]"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
@@ -89,7 +130,7 @@ export function ComparisonSection() {
                           d="M5 13l4 4L19 7"
                         />
                       </svg>
-                      <p className="text-blue-700">{item.jovie}</p>
+                      <p className="text-[var(--accent-700)]">{item.jovie}</p>
                     </div>
                   </div>
                 </div>

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -1,71 +1,99 @@
-export function HowItWorks() {
-  const steps = [
-    {
-      number: '01',
-      title: 'Connect',
-      description: 'Search and verify your Spotify artist profile',
-      icon: (
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-          />
-        </svg>
-      ),
+type Step = {
+  number: string;
+  title: string;
+  description: string;
+  icon: JSX.Element;
+  accent: React.CSSProperties;
+};
+
+const defaultSteps: Step[] = [
+  {
+    number: '01',
+    title: 'Connect',
+    description: 'Search and verify your Spotify artist profile',
+    accent: {
+      '--accent-50': 'var(--color-orange-50)',
+      '--accent-400': 'var(--color-orange-400)',
+      '--accent-600': 'var(--color-orange-600)',
     },
-    {
-      number: '02',
-      title: 'Claim',
-      description: 'Get your custom jov.ie/yourname link',
-      icon: (
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-          />
-        </svg>
-      ),
+    icon: (
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+        />
+      </svg>
+    ),
+  },
+  {
+    number: '02',
+    title: 'Claim',
+    description: 'Get your custom jov.ie/yourname link',
+    accent: {
+      '--accent-50': 'var(--color-orange-50)',
+      '--accent-400': 'var(--color-orange-400)',
+      '--accent-600': 'var(--color-orange-600)',
     },
-    {
-      number: '03',
-      title: 'Convert',
-      description: 'Fans click "Listen Now" and stream your music',
-      icon: (
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293H15"
-          />
-        </svg>
-      ),
+    icon: (
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+        />
+      </svg>
+    ),
+  },
+  {
+    number: '03',
+    title: 'Convert',
+    description: 'Fans click "Listen Now" and stream your music',
+    accent: {
+      '--accent-50': 'var(--color-orange-50)',
+      '--accent-400': 'var(--color-orange-400)',
+      '--accent-600': 'var(--color-orange-600)',
     },
-  ];
+    icon: (
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1.586a1 1 0 01.707.293l2.414 2.414a1 1 0 00.707.293H15"
+        />
+      </svg>
+    ),
+  },
+];
+
+export function HowItWorks({ steps = defaultSteps }: { steps?: Step[] }) {
+  const sectionAccent = steps[0]?.accent;
 
   return (
-    <section className="relative bg-gray-50 py-24 sm:py-32">
+    <section
+      style={sectionAccent}
+      className="relative bg-gray-50 py-24 sm:py-32"
+    >
       {/* Section accent border */}
-      <div className="absolute top-0 left-0 right-0 h-1 bg-linear-to-r from-orange-400 to-orange-600" />
+      <div className="absolute top-0 left-0 right-0 h-1 bg-linear-to-r from-[var(--accent-400)] to-[var(--accent-600)]" />
 
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
@@ -76,18 +104,18 @@ export function HowItWorks() {
         <div className="mx-auto mt-20 max-w-6xl">
           <div className="grid grid-cols-1 gap-12 md:grid-cols-3">
             {steps.map((step, index) => (
-              <div key={step.number} className="relative">
+              <div key={step.number} className="relative" style={step.accent}>
                 {/* Connection line - Apple-style */}
                 {index < steps.length - 1 && (
-                  <div className="absolute left-1/2 top-8 hidden h-px w-full -translate-x-1/2 bg-linear-to-r from-orange-400/50 to-orange-600/50 md:block" />
+                  <div className="absolute left-1/2 top-8 hidden h-px w-full -translate-x-1/2 bg-linear-to-r from-[var(--accent-400)] to-[var(--accent-600)] opacity-50 md:block" />
                 )}
 
                 <div className="text-center">
-                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-orange-500 to-orange-600 text-white shadow-xs">
+                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-[var(--accent-50)] to-[var(--accent-600)] text-white shadow-xs">
                     {step.icon}
                   </div>
                   <div className="mt-6">
-                    <div className="text-xs font-semibold uppercase tracking-wider text-orange-600">
+                    <div className="text-xs font-semibold uppercase tracking-wider text-[var(--accent-600)]">
                       Step {step.number}
                     </div>
                     <h3 className="mt-3 text-xl font-bold text-gray-900">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,30 @@
   --color-gray-800: #1f2937;
   --color-gray-900: #111827;
 
+  /* Accent palettes */
+  --color-orange-50: oklch(98% 0.016 73.684);
+  --color-orange-400: oklch(75% 0.183 55.934);
+  --color-orange-600: oklch(64.6% 0.222 41.116);
+
+  --color-violet-50: oklch(96.9% 0.016 293.756);
+  --color-violet-100: oklch(94.3% 0.029 294.588);
+  --color-violet-200: oklch(89.4% 0.057 293.283);
+  --color-violet-400: oklch(70.2% 0.183 293.541);
+  --color-violet-500: oklch(60.6% 0.25 292.717);
+  --color-violet-600: oklch(54.1% 0.281 293.009);
+  --color-violet-700: oklch(49.1% 0.27 292.581);
+  --color-violet-900: oklch(38% 0.189 293.745);
+
+  --color-red-25: #fff5f5;
+  --color-red-50: oklch(97.1% 0.013 17.38);
+  --color-red-900: oklch(39.6% 0.141 25.723);
+
+  --color-blue-25: #f5faff;
+  --color-blue-50: oklch(97% 0.014 254.604);
+  --color-blue-500: oklch(62.3% 0.214 259.815);
+  --color-blue-700: oklch(48.8% 0.243 264.376);
+  --color-blue-900: oklch(37.9% 0.146 265.522);
+
   --tracking-tighter: -0.02em;
   --tracking-tight: -0.01em;
   --tracking-normal: 0;
@@ -99,6 +123,17 @@
   :root {
     --background: 255 255 255;
     --foreground: 17 24 39;
+
+    /* Default accent set to violet */
+    --accent-25: var(--color-violet-50);
+    --accent-50: var(--color-violet-50);
+    --accent-100: var(--color-violet-100);
+    --accent-200: var(--color-violet-200);
+    --accent-400: var(--color-violet-400);
+    --accent-500: var(--color-violet-500);
+    --accent-600: var(--color-violet-600);
+    --accent-700: var(--color-violet-700);
+    --accent-900: var(--color-violet-900);
   }
 
   .dark {


### PR DESCRIPTION
## Summary
- centralize accent palettes with CSS variables
- allow marketing sections to receive accent props
- replace hard-coded color classes with CSS variable tokens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc93e472c83278f5f0f4d5fd411d3