### PR TITLE
feat: simplify marketing colors with accent tokens

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -136,16 +136,16 @@ export default function HomePage() {
         }}
       />
 
-      <div className="relative min-h-screen overflow-hidden bg-linear-to-br from-indigo-900 via-purple-900 to-pink-900">
+      <div className="relative min-h-screen overflow-hidden bg-black">
         {/* Background Pattern */}
         <div className="absolute inset-0 opacity-50">
-          <div className="absolute inset-0 bg-linear-to-br from-white/5 to-transparent" />
+          <div className="absolute inset-0 bg-[var(--accent-hero)]/5" />
         </div>
 
         {/* Floating Elements */}
         <div className="absolute inset-0 overflow-hidden">
-          <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-linear-to-br from-indigo-500/20 to-purple-500/20 blur-3xl" />
-          <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-linear-to-tr from-pink-500/20 to-purple-500/20 blur-3xl" />
+          <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-[var(--accent-hero)]/20 blur-3xl" />
+          <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-[var(--accent-features)]/20 blur-3xl" />
         </div>
 
         {/* Hero Section */}

--- a/components/home/ArtistCarousel.tsx
+++ b/components/home/ArtistCarousel.tsx
@@ -21,7 +21,7 @@ export function ArtistCarousel({ artists }: ArtistCarouselProps) {
   }
 
   return (
-    <section className="relative w-full bg-linear-to-r from-indigo-50 via-purple-50 to-pink-50 dark:from-indigo-950 dark:via-purple-950 dark:to-pink-950 py-16">
+    <section className="relative w-full bg-white dark:bg-black py-16 border-t border-[var(--accent-features)]">
       {/* Full-width horizontal scroll container */}
       <div className="relative overflow-x-auto overflow-y-hidden">
         {/* Artist images row */}

--- a/components/home/ArtistSearch.tsx
+++ b/components/home/ArtistSearch.tsx
@@ -98,7 +98,8 @@ export function ArtistSearch() {
               disabled={!selectedArtist}
               variant="primary"
               size="sm"
-              className="rounded-lg bg-linear-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+              accent="hero"
+              className="disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
             >
               Claim Profile
             </Button>

--- a/components/home/BenefitsSection.tsx
+++ b/components/home/BenefitsSection.tsx
@@ -77,14 +77,14 @@ export function BenefitsSection() {
           <div className="grid grid-cols-1 gap-12 md:grid-cols-3">
             {benefits.map((benefit) => (
               <div key={benefit.title} className="text-center">
-                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-violet-500 to-violet-600 text-white shadow-xs">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[var(--accent-features)] text-white shadow-xs">
                   {benefit.icon}
                 </div>
                 <h3 className="mt-6 text-xl font-bold text-gray-900">
                   {benefit.title}
                 </h3>
                 {/* Violet accent dot */}
-                <div className="mx-auto mt-3 h-1 w-1 rounded-full bg-violet-500" />
+                <div className="mx-auto mt-3 h-1 w-1 rounded-full bg-[var(--accent-features)]" />
                 <p className="mt-4 text-gray-600 leading-relaxed">
                   {benefit.description}
                 </p>

--- a/components/home/FeaturedArtists.tsx
+++ b/components/home/FeaturedArtists.tsx
@@ -13,7 +13,7 @@ interface Artist {
 }
 
 const Skeleton = () => (
-  <div className="h-16 w-16 shrink-0 rounded-full bg-slate-400/20 animate-pulse snap-center" />
+  <div className="h-16 w-16 shrink-0 rounded-full bg-[var(--accent-features)]/20 animate-pulse snap-center" />
 );
 
 export function FeaturedArtists() {
@@ -32,7 +32,7 @@ export function FeaturedArtists() {
   }, []);
 
   return (
-    <section className="relative bg-linear-to-b from-indigo-600/90 to-pink-600/90 py-14 lg:py-20">
+    <section className="relative bg-black py-14 lg:py-20 border-t border-[var(--accent-features)]">
       <div className="mx-auto max-w-[1200px] px-6 lg:px-8">
         <div
           className="flex gap-6 overflow-x-auto snap-x snap-mandatory"

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -10,8 +10,8 @@ export function HomeHero() {
       role="banner"
       aria-labelledby="hero-headline"
     >
-      {/* Subtle gradient overlay for depth */}
-      <div className="absolute inset-0 bg-linear-to-b from-purple-50/5 to-transparent" />
+      {/* Subtle accent overlay for depth */}
+      <div className="absolute inset-0 bg-[var(--accent-hero)]/5" />
 
       <Container className="relative flex max-w-4xl flex-col items-center text-center">
         {/* Hero Section - Above the fold */}
@@ -35,7 +35,7 @@ export function HomeHero() {
             className="text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl"
           >
             <span className="block text-white">The fastest link-in-bio</span>
-            <span className="block bg-linear-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            <span className="block text-[var(--accent-hero)]">
               Built for musicians
             </span>
           </h1>

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -65,7 +65,7 @@ export function HowItWorks() {
   return (
     <section className="relative bg-gray-50 py-24 sm:py-32">
       {/* Section accent border */}
-      <div className="absolute top-0 left-0 right-0 h-1 bg-linear-to-r from-orange-400 to-orange-600" />
+      <div className="absolute top-0 left-0 right-0 h-1 bg-[var(--accent-features)]" />
 
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
@@ -79,15 +79,15 @@ export function HowItWorks() {
               <div key={step.number} className="relative">
                 {/* Connection line - Apple-style */}
                 {index < steps.length - 1 && (
-                  <div className="absolute left-1/2 top-8 hidden h-px w-full -translate-x-1/2 bg-linear-to-r from-orange-400/50 to-orange-600/50 md:block" />
+                  <div className="absolute left-1/2 top-8 hidden h-px w-full -translate-x-1/2 bg-[var(--accent-features)]/50 md:block" />
                 )}
 
                 <div className="text-center">
-                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-orange-500 to-orange-600 text-white shadow-xs">
+                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[var(--accent-features)] text-white shadow-xs">
                     {step.icon}
                   </div>
                   <div className="mt-6">
-                    <div className="text-xs font-semibold uppercase tracking-wider text-orange-600">
+                    <div className="text-xs font-semibold uppercase tracking-wider text-[var(--accent-features)]">
                       Step {step.number}
                     </div>
                     <h3 className="mt-3 text-xl font-bold text-gray-900">

--- a/components/home/PreFooterCTA.tsx
+++ b/components/home/PreFooterCTA.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 export function PreFooterCTA() {
   return (
-    <section className="w-full bg-linear-to-br from-blue-600 via-purple-600 to-pink-600 py-24 px-4">
+    <section className="w-full bg-black py-24 px-4 border-t border-[var(--accent-hero)]">
       <div className="max-w-2xl mx-auto text-center">
         <h2 className="text-4xl sm:text-5xl font-bold text-white mb-6">
           Stop losing fans to ugly link pages.
@@ -14,7 +14,7 @@ export function PreFooterCTA() {
         </p>
         <Link
           href="/sign-in"
-          className="inline-flex items-center justify-center rounded-full bg-white text-blue-700 hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-white/20 px-8 py-3 text-lg font-semibold transition-all duration-200 shadow-xs"
+          className="inline-flex items-center justify-center rounded-full bg-[var(--accent-hero)] text-white hover:opacity-90 focus:outline-hidden focus:ring-2 focus:ring-white/20 px-8 py-3 text-lg font-semibold transition-all duration-200 shadow-xs"
         >
           Get Your jov.ie Link
         </Link>

--- a/components/home/WaitlistLink.tsx
+++ b/components/home/WaitlistLink.tsx
@@ -19,7 +19,8 @@ export function WaitlistLink() {
               <Button
                 variant="primary"
                 size="lg"
-                className="rounded-lg bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700 transition-all duration-200"
+                accent="hero"
+                className="transition-all duration-200"
               >
                 Join Waitlist
               </Button>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -4,6 +4,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'ghost' | 'outline' | 'plain';
   size?: 'sm' | 'md' | 'lg';
   color?: 'indigo' | 'red' | 'green';
+  accent?: 'hero' | 'features';
   children: React.ReactNode;
   href?: string;
   className?: string;
@@ -18,6 +19,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'primary',
       size = 'md',
       color = 'indigo',
+      accent,
       className = '',
       children,
       as: Component = 'button',
@@ -56,11 +58,18 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       green: 'bg-green-600 text-white hover:bg-green-700 focus:ring-green-500',
     };
 
+    const accentClasses = {
+      hero: 'bg-[var(--accent-hero)] text-white hover:opacity-90 focus:ring-[var(--accent-hero)]',
+      features:
+        'bg-[var(--accent-features)] text-white hover:opacity-90 focus:ring-[var(--accent-features)]',
+    } as const;
+
     // Determine which classes to use based on props
     let variantClass = variantClasses[variant];
     if (outline) variantClass = variantClasses.outline;
     if (plain) variantClass = variantClasses.plain;
     if (color && variant === 'primary') variantClass = colorClasses[color];
+    if (accent) variantClass = accentClasses[accent];
 
     const classes =
       `${baseClasses} ${variantClass} ${sizeClasses[size]} ${className}`.trim();

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -99,6 +99,8 @@
   :root {
     --background: 255 255 255;
     --foreground: 17 24 39;
+    --accent-hero: #a855f7;
+    --accent-features: #f97316;
   }
 
   .dark {


### PR DESCRIPTION
## Summary
- add reusable accent color tokens
- remove marketing gradients in favor of solid backgrounds
- support accent prop in shared Button for consistent theming

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc925dc3883279007ef1d49e27cda