### PR TITLE
feat: add artist import edge function

### DIFF
--- a/components/bridge/PendingClaimRunner.tsx
+++ b/components/bridge/PendingClaimRunner.tsx
@@ -4,12 +4,6 @@ import { useEffect, useState } from 'react';
 import { useUser } from '@clerk/nextjs';
 import { useRouter } from 'next/navigation';
 import { createBrowserClient } from '@/lib/supabase';
-import {
-  getSpotifyArtist,
-  getArtistLatestRelease,
-  buildSpotifyAlbumUrl,
-} from '@/lib/spotify';
-import { generateHandle } from '@/lib/utils';
 import { track } from '@/lib/analytics';
 
 interface PendingClaim {
@@ -29,172 +23,45 @@ export function PendingClaimRunner() {
     if (!isSignedIn || !user || isProcessing) return;
 
     const processPendingClaim = async () => {
-      try {
-        // Check for pending claim in sessionStorage
-        const pendingClaimStr = sessionStorage.getItem('pendingClaim');
-        if (!pendingClaimStr) return;
+      // Check for pending claim in sessionStorage
+      const pendingClaimStr = sessionStorage.getItem('pendingClaim');
+      if (!pendingClaimStr) return;
 
-        const pendingClaim: PendingClaim = JSON.parse(pendingClaimStr);
+      const pendingClaim: PendingClaim = JSON.parse(pendingClaimStr);
 
-        // Check if claim is still valid (within 1 hour)
-        const now = Date.now();
-        if (now - pendingClaim.timestamp > 60 * 60 * 1000) {
-          sessionStorage.removeItem('pendingClaim');
-          return;
-        }
+      // Check if claim is still valid (within 1 hour)
+      const now = Date.now();
+      if (now - pendingClaim.timestamp > 60 * 60 * 1000) {
+        sessionStorage.removeItem('pendingClaim');
+        return;
+      }
 
-        setIsProcessing(true);
+      setIsProcessing(true);
 
-        // Get or create user in database
-        const { data: existingUser, error: userError } = await supabase
-          .from('users')
-          .select('id')
-          .eq('clerk_id', user.id)
-          .single();
+      const { data, error } = await supabase.functions.invoke('import-artist', {
+        body: {
+          spotifyId: pendingClaim.spotifyId,
+          clerkId: user.id,
+          email: user.primaryEmailAddress?.emailAddress,
+        },
+      });
 
-        let userId;
-        if (userError && userError.code === 'PGRST116') {
-          const { data: newUser, error: createUserError } = await supabase
-            .from('users')
-            .insert({
-              clerk_id: user.id,
-              email: user.primaryEmailAddress?.emailAddress || '',
-            })
-            .select('id')
-            .single();
+      sessionStorage.removeItem('pendingClaim');
 
-          if (createUserError) throw createUserError;
-          userId = newUser.id;
-        } else if (userError) {
-          throw userError;
-        } else {
-          userId = existingUser.id;
-        }
-
-        // Check if artist already exists for this user
-        const { data: existingArtist } = await supabase
-          .from('artists')
-          .select('handle')
-          .eq('owner_user_id', userId)
-          .eq('spotify_id', pendingClaim.spotifyId)
-          .single();
-
-        if (existingArtist) {
-          // Artist already claimed by this user, redirect to dashboard
-          sessionStorage.removeItem('pendingClaim');
-          router.push('/dashboard');
-          return;
-        }
-
-        // Check if artist is claimed by another user
-        const { data: claimedByOther } = await supabase
-          .from('artists')
-          .select('id')
-          .eq('spotify_id', pendingClaim.spotifyId)
-          .neq('owner_user_id', userId)
-          .single();
-
-        if (claimedByOther) {
-          setError('This artist is already claimed by another user.');
-          sessionStorage.removeItem('pendingClaim');
-          return;
-        }
-
-        // Fetch artist data from Spotify
-        const spotifyArtist = await getSpotifyArtist(pendingClaim.spotifyId);
-        const suggestedHandle = generateHandle(spotifyArtist.name);
-
-        // Insert artist
-        const { data: artist, error: artistError } = await supabase
-          .from('artists')
-          .insert({
-            owner_user_id: userId,
-            handle: suggestedHandle,
-            spotify_id: pendingClaim.spotifyId,
-            name: spotifyArtist.name,
-            image_url: spotifyArtist.images?.[0]?.url,
-          })
-          .select('*')
-          .single();
-
-        let finalArtist = artist;
-
-        if (artistError) {
-          if (artistError.code === '23505') {
-            // Handle conflict, try with numeric suffix
-            let counter = 1;
-            let finalHandle = suggestedHandle;
-            let inserted = false;
-
-            while (!inserted && counter < 10) {
-              finalHandle = `${suggestedHandle}${counter}`;
-              const { data: retryArtist, error: retryError } = await supabase
-                .from('artists')
-                .insert({
-                  owner_user_id: userId,
-                  handle: finalHandle,
-                  spotify_id: pendingClaim.spotifyId,
-                  name: spotifyArtist.name,
-                  image_url: spotifyArtist.images?.[0]?.url,
-                })
-                .select('*')
-                .single();
-
-              if (!retryError) {
-                inserted = true;
-                finalArtist = retryArtist;
-              } else if (retryError.code !== '23505') {
-                throw retryError;
-              }
-              counter++;
-            }
-
-            if (!inserted || !finalArtist) {
-              throw new Error('Could not generate unique handle');
-            }
-          } else {
-            throw artistError;
-          }
-        }
-
-        if (!finalArtist) {
-          throw new Error('Failed to create artist profile');
-        }
-
-        // Try to fetch and insert latest release
-        try {
-          const latestRelease = await getArtistLatestRelease(
-            pendingClaim.spotifyId
-          );
-          if (latestRelease) {
-            await supabase.from('releases').insert({
-              artist_id: finalArtist.id,
-              dsp: 'spotify',
-              title: latestRelease.name,
-              url: buildSpotifyAlbumUrl(latestRelease.id),
-              release_date: latestRelease.release_date,
-            });
-          }
-        } catch (releaseError) {
-          console.warn('Failed to fetch latest release:', releaseError);
-        }
-
-        // Track successful claim
+      if (error || data?.error) {
+        console.error('Error processing pending claim:', error || data?.error);
+        setError(
+          (data?.error as string) || "We couldn't claim your artist profile."
+        );
+      } else {
         track('artist_claim_success', {
-          handle: finalArtist.handle,
+          handle: data.handle,
           spotifyId: pendingClaim.spotifyId,
         });
-
-        // Clear pending claim and redirect
-        sessionStorage.removeItem('pendingClaim');
         router.push('/dashboard');
-      } catch (err) {
-        console.error('Error processing pending claim:', err);
-        setError(err instanceof Error ? err.message : 'Failed to claim artist');
-        sessionStorage.removeItem('pendingClaim');
-      } finally {
-        setIsProcessing(false);
       }
+
+      setIsProcessing(false);
     };
 
     processPendingClaim();

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -19,11 +19,16 @@ async function getSpotifyToken(): Promise<string> {
   }
 
   try {
+    const basicAuth =
+      typeof Buffer !== 'undefined'
+        ? Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+        : btoa(`${clientId}:${clientSecret}`);
+
     const response = await fetch('https://accounts.spotify.com/api/token', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
-        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${basicAuth}`,
       },
       body: 'grant_type=client_credentials',
     });

--- a/supabase/functions/import-artist/index.ts
+++ b/supabase/functions/import-artist/index.ts
@@ -1,0 +1,147 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+import {
+  getSpotifyArtist,
+  getArtistLatestRelease,
+  buildSpotifyAlbumUrl,
+} from '../../../lib/spotify.ts';
+import { generateHandle } from '../../../lib/utils.ts';
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  try {
+    const { spotifyId, clerkId, email } = await req.json();
+    if (!spotifyId || !clerkId) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required parameters' }),
+        { status: 400 }
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const serviceRole = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    if (!supabaseUrl || !serviceRole) {
+      throw new Error('Supabase credentials not configured');
+    }
+    const supabase = createClient(supabaseUrl, serviceRole);
+
+    // Get or create user
+    const { data: existingUser, error: userError } = await supabase
+      .from('users')
+      .select('id')
+      .eq('clerk_id', clerkId)
+      .single();
+
+    let userId;
+    if (userError && userError.code === 'PGRST116') {
+      const { data: newUser, error: createUserError } = await supabase
+        .from('users')
+        .insert({ clerk_id: clerkId, email: email || '' })
+        .select('id')
+        .single();
+      if (createUserError) throw createUserError;
+      userId = newUser.id;
+    } else if (userError) {
+      throw userError;
+    } else {
+      userId = existingUser.id;
+    }
+
+    // Already claimed by this user?
+    const { data: existingArtist } = await supabase
+      .from('artists')
+      .select('handle')
+      .eq('owner_user_id', userId)
+      .eq('spotify_id', spotifyId)
+      .single();
+    if (existingArtist) {
+      return new Response(
+        JSON.stringify({ status: 'success', handle: existingArtist.handle }),
+        { status: 200 }
+      );
+    }
+
+    // Claimed by another?
+    const { data: claimedByOther } = await supabase
+      .from('artists')
+      .select('id')
+      .eq('spotify_id', spotifyId)
+      .neq('owner_user_id', userId)
+      .single();
+    if (claimedByOther) {
+      return new Response(JSON.stringify({ error: 'Artist already claimed' }), {
+        status: 409,
+      });
+    }
+
+    const spotifyArtist = await getSpotifyArtist(spotifyId);
+    const baseHandle = generateHandle(spotifyArtist.name);
+
+    const insertArtist = async (handle: string) =>
+      supabase
+        .from('artists')
+        .insert({
+          owner_user_id: userId,
+          handle,
+          spotify_id: spotifyId,
+          name: spotifyArtist.name,
+          image_url: spotifyArtist.images?.[0]?.url,
+        })
+        .select('*')
+        .single();
+
+    const { data: initialArtist, error: artistError } =
+      await insertArtist(baseHandle);
+    let artist = initialArtist;
+    if (artistError && artistError.code === '23505') {
+      let counter = 1;
+      let finalArtist = null;
+      while (!finalArtist && counter < 10) {
+        const attempt = await insertArtist(`${baseHandle}${counter}`);
+        if (!attempt.error) {
+          finalArtist = attempt.data;
+        } else if (attempt.error.code !== '23505') {
+          throw attempt.error;
+        }
+        counter++;
+      }
+      if (!finalArtist) throw new Error('Could not generate unique handle');
+      artist = finalArtist;
+    } else if (artistError) {
+      throw artistError;
+    }
+
+    // Insert latest release if available
+    try {
+      const latest = await getArtistLatestRelease(spotifyId);
+      if (latest) {
+        await supabase.from('releases').insert({
+          artist_id: artist.id,
+          dsp: 'spotify',
+          title: latest.name,
+          url: buildSpotifyAlbumUrl(latest.id),
+          release_date: latest.release_date,
+        });
+      }
+    } catch (err) {
+      console.warn('Failed to fetch latest release', err);
+    }
+
+    return new Response(
+      JSON.stringify({ status: 'success', handle: artist.handle }),
+      { status: 200 }
+    );
+  } catch (err) {
+    console.error('Import artist error', err);
+    return new Response(
+      JSON.stringify({
+        error: err instanceof Error ? err.message : 'Unknown error',
+      }),
+      { status: 500 }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add Supabase edge function to import artists and seed initial releases
- invoke edge function from PendingClaimRunner to handle Spotify claims server-side
- make Spotify token retrieval compatible with edge runtime

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ff3ea95548327adc2dd952b98ac1c