### PR TITLE
feat: differentiate cache policies for html and assets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -35,22 +35,26 @@ const nextConfig = {
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
   },
   async headers() {
+    const securityHeaders = [
+      {
+        key: 'X-Frame-Options',
+        value: 'DENY',
+      },
+      {
+        key: 'X-Content-Type-Options',
+        value: 'nosniff',
+      },
+      {
+        key: 'Referrer-Policy',
+        value: 'origin-when-cross-origin',
+      },
+    ];
     return [
       {
-        source: '/(.*)',
+        source:
+          '/:path*\\.(?:js|css|svg|png|jpg|jpeg|gif|ico|webp|avif|woff|woff2|ttf|otf)',
         headers: [
-          {
-            key: 'X-Frame-Options',
-            value: 'DENY',
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'origin-when-cross-origin',
-          },
+          ...securityHeaders,
           {
             key: 'Cache-Control',
             value: 'public, max-age=31536000, immutable',
@@ -60,9 +64,20 @@ const nextConfig = {
       {
         source: '/api/(.*)',
         headers: [
+          ...securityHeaders,
           {
             key: 'Cache-Control',
             value: 'public, max-age=300, s-maxage=300', // 5 minutes
+          },
+        ],
+      },
+      {
+        source: '/(.*)',
+        headers: [
+          ...securityHeaders,
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- separate security headers from cache policies and set long-term caching only for static assets
- ensure HTML pages revalidate on each request with `max-age=0`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925e2fa96c8327a24d550685bfbbd6