### PR TITLE
build: enforce eslint during builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   turbopack: {},
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   typescript: {
     ignoreBuildErrors: false,
   },


### PR DESCRIPTION
## Summary
- remove eslint.ignoreDuringBuilds so builds fail on lint errors

## Testing
- `npm run lint`
- `npm run lint` with a temporary lint error (expected failure)
- `npm test`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68925e29bf948327b8279130c84f6d98