### PR TITLE
refactor: derive artist search flag

### DIFF
--- a/constants/app.ts
+++ b/constants/app.ts
@@ -9,13 +9,16 @@ export const ANALYTICS = {
 };
 
 // Feature flags
+const waitlistEnabled = process.env.NEXT_PUBLIC_WAITLIST_ENABLED === 'true';
+const artistSearchEnabled = !waitlistEnabled;
+
 export const FEATURE_FLAGS = {
   // Control waitlist mode via environment variable
   // When WAITLIST_ENABLED=true: show waitlist page, hide artist search, convert sign-up buttons to waitlist buttons
   // When WAITLIST_ENABLED=false or not set: normal functionality with artist search and sign-up
-  waitlistEnabled: process.env.NEXT_PUBLIC_WAITLIST_ENABLED === 'true',
+  waitlistEnabled,
   // Artist search is enabled when waitlist mode is disabled
-  artistSearchEnabled: process.env.NEXT_PUBLIC_WAITLIST_ENABLED !== 'true',
+  artistSearchEnabled,
 };
 export const LEGAL = {
   privacyPath: '/legal/privacy',


### PR DESCRIPTION
## Summary
- derive `artistSearchEnabled` flag from `waitlistEnabled`

## Testing
- `npm run lint -- --file constants/app.ts`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925e195e808327ad4e9610e51bdf9d