### PR TITLE
fix: add GITHUB_TOKEN to danger job in pr-verify workflow

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -78,3 +78,5 @@ jobs:
 
       - run: npm ci
       - run: npm run danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🔧 **Issue Fixed:**

The Danger CI check was failing with the error:


## ✅ **Solution:**

Added the  environment variable to the danger job in the PR verification workflow:



## 📋 **Changes:**
- Updated 
- Added  environment variable to the danger job
- This will allow Danger to properly authenticate and comment on PRs

## 🧪 **Testing:**
- The fix follows the same pattern as other jobs in the workflow
- Uses the standard  pattern
- Should resolve the authentication error in future PRs