### PR TITLE
perf: remove lighthouse CI from develop workflow for faster builds

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -100,14 +100,6 @@ jobs:
       #     npx playwright install --with-deps
       #     BASE_URL="${{ steps.vercel.outputs.url }}" npm run e2e:smoke --if-present
 
-      - name: Lighthouse budgets
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          urls: ${{ steps.vercel.outputs.url }}
-          configPath: .lighthouserc.json
-          uploadArtifacts: true
-          temporaryPublicStorage: true
-
       - name: Dependency security (high+)
         run: npx audit-ci --moderate --allowlist "npm:*" || npm audit --audit-level=high
 


### PR DESCRIPTION
## Performance Improvement

### **Changes Made:**

**Removed Lighthouse CI from Develop Workflow:**
- Removed the  step from 
- Lighthouse CI will now only run in the preview CI workflow
- This significantly speeds up the develop branch builds

### **Why This Change:**

1. **Faster Develop Builds**: Lighthouse CI can take 2-3 minutes to run, slowing down the develop workflow
2. **Better CI Strategy**: Lighthouse performance testing is more valuable at the preview stage before production
3. **Maintained Coverage**: Lighthouse CI is still active in the preview workflow where it's most needed

### **Current CI Strategy:**

**Develop Workflow (Fast):**
- ✅ Build, test, lint, typecheck
- ✅ Deploy to develop environment
- ✅ Security audit
- ✅ Auto-promote to preview

**Preview Workflow (Comprehensive):**
- ✅ All develop checks
- ✅ E2E tests (all browsers)
- ✅ Lighthouse performance audit
- ✅ Bundle size analysis
- ✅ Security scan (ZAP)
- ✅ Auto-promote to main

### **Benefits:**
- **Faster feedback** on develop branch changes
- **Maintained quality gates** at preview stage
- **Better developer experience** with quicker CI cycles