### PR TITLE
Add header and footer to legal pages

### DIFF
--- a/app/(dynamic)/legal/layout.tsx
+++ b/app/(dynamic)/legal/layout.tsx
@@ -1,3 +1,7 @@
+import { Header } from '@/components/site/Header';
+import { Footer } from '@/components/site/Footer';
+import { Container } from '@/components/site/Container';
+
 // Force dynamic rendering for all legal pages
 export const dynamic = 'force-dynamic';
 
@@ -6,5 +10,15 @@ export default function LegalLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return (
+    <div className="flex min-h-screen flex-col bg-[#0D0E12]">
+      <Header />
+      <main className="flex-1 py-12">
+        <Container>
+          <div className="mx-auto max-w-3xl">{children}</div>
+        </Container>
+      </main>
+      <Footer />
+    </div>
+  );
 }

--- a/app/(dynamic)/legal/privacy/page.tsx
+++ b/app/(dynamic)/legal/privacy/page.tsx
@@ -1,34 +1,10 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { Container } from '@/components/site/Container';
+import { LegalContent } from '@/components/legal/LegalContent';
 
 export default function PrivacyPage() {
-  const [contentHtml, setContentHtml] = useState<string>('');
-
-  useEffect(() => {
-    // Fetch the content from an API route
-    fetch('/api/legal/privacy')
-      .then((res) => res.text())
-      .then((html) => setContentHtml(html))
-      .catch((err) => {
-        console.error('Failed to load privacy:', err);
-        setContentHtml('<p>Failed to load privacy policy.</p>');
-      });
-  }, []);
-
   return (
-    <div className="flex min-h-screen flex-col bg-[#0D0E12]">
-      <main className="flex-1 py-12">
-        <Container>
-          <div className="mx-auto max-w-3xl">
-            <div
-              className="prose prose-invert max-w-none prose-headings:text-white prose-p:text-white/70 prose-a:text-blue-400 prose-strong:text-white prose-code:text-white prose-pre:bg-white/5 prose-pre:border prose-pre:border-white/10"
-              dangerouslySetInnerHTML={{ __html: contentHtml }}
-            />
-          </div>
-        </Container>
-      </main>
-    </div>
+    <LegalContent
+      endpoint="/api/legal/privacy"
+      fallbackHtml="<p>Failed to load privacy policy.</p>"
+    />
   );
 }

--- a/app/(dynamic)/legal/terms/page.tsx
+++ b/app/(dynamic)/legal/terms/page.tsx
@@ -1,34 +1,10 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { Container } from '@/components/site/Container';
+import { LegalContent } from '@/components/legal/LegalContent';
 
 export default function TermsPage() {
-  const [contentHtml, setContentHtml] = useState<string>('');
-
-  useEffect(() => {
-    // Fetch the content from an API route
-    fetch('/api/legal/terms')
-      .then((res) => res.text())
-      .then((html) => setContentHtml(html))
-      .catch((err) => {
-        console.error('Failed to load terms:', err);
-        setContentHtml('<p>Failed to load terms of service.</p>');
-      });
-  }, []);
-
   return (
-    <div className="flex min-h-screen flex-col bg-[#0D0E12]">
-      <main className="flex-1 py-12">
-        <Container>
-          <div className="mx-auto max-w-3xl">
-            <div
-              className="prose prose-invert max-w-none prose-headings:text-white prose-p:text-white/70 prose-a:text-blue-400 prose-strong:text-white prose-code:text-white prose-pre:bg-white/5 prose-pre:border prose-pre:border-white/10"
-              dangerouslySetInnerHTML={{ __html: contentHtml }}
-            />
-          </div>
-        </Container>
-      </main>
-    </div>
+    <LegalContent
+      endpoint="/api/legal/terms"
+      fallbackHtml="<p>Failed to load terms of service.</p>"
+    />
   );
 }

--- a/components/legal/LegalContent.tsx
+++ b/components/legal/LegalContent.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface LegalContentProps {
+  endpoint: string;
+  fallbackHtml: string;
+}
+
+export function LegalContent({ endpoint, fallbackHtml }: LegalContentProps) {
+  const [contentHtml, setContentHtml] = useState('');
+
+  useEffect(() => {
+    fetch(endpoint)
+      .then((res) => res.text())
+      .then(setContentHtml)
+      .catch((err) => {
+        console.error(`Failed to load ${endpoint}:`, err);
+        setContentHtml(fallbackHtml);
+      });
+  }, [endpoint, fallbackHtml]);
+
+  return (
+    <div
+      className="prose prose-invert max-w-none prose-headings:text-white prose-p:text-white/70 prose-a:text-blue-400 prose-strong:text-white prose-code:text-white prose-pre:bg-white/5 prose-pre:border prose-pre:border-white/10"
+      dangerouslySetInnerHTML={{ __html: contentHtml }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add global header and footer for legal pages via shared layout
- introduce reusable `LegalContent` component
- refactor terms and privacy pages to use shared component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b6a9442c8327bd179924212fcaa6