### PR TITLE
feat: add tip promo section to homepage

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -7,7 +7,8 @@ import { HowItWorks } from '@/components/home/HowItWorks';
 import { BenefitsSection } from '@/components/home/BenefitsSection';
 import { SocialProofSection } from '@/components/home/ComparisonSection';
 import { PreFooterCTA } from '@/components/home/PreFooterCTA';
-import TipPromo from '@/components/TipPromo';
+import dynamic from 'next/dynamic';
+const TipPromo = dynamic(() => import('@/components/TipPromo'));
 import { APP_NAME, APP_URL } from '@/constants/app';
 
 // Root layout handles dynamic rendering


### PR DESCRIPTION
## Summary
- dynamically load TipPromo component on marketing homepage

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: Failed to launch Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_6893b679c51c8327868be80ad27d0438