### PR TITLE
feat: add profile preview and link validation

### DIFF
--- a/components/dashboard/ListenNowForm.tsx
+++ b/components/dashboard/ListenNowForm.tsx
@@ -23,6 +23,41 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
     youtube_url: artist.youtube_url || '',
   });
 
+  const validateLinks = () => {
+    try {
+      if (formData.spotify_url) {
+        const url = new URL(formData.spotify_url);
+        if (!url.hostname.includes('open.spotify.com')) {
+          setError('Please enter a valid Spotify URL.');
+          return false;
+        }
+      }
+
+      if (formData.apple_music_url) {
+        const url = new URL(formData.apple_music_url);
+        if (!url.hostname.includes('music.apple.com')) {
+          setError('Please enter a valid Apple Music URL.');
+          return false;
+        }
+      }
+
+      if (formData.youtube_url) {
+        const url = new URL(formData.youtube_url);
+        if (
+          !url.hostname.includes('youtube.com') &&
+          !url.hostname.includes('youtu.be')
+        ) {
+          setError('Please enter a valid YouTube URL.');
+          return false;
+        }
+      }
+    } catch {
+      setError('Please enter valid streaming URLs.');
+      return false;
+    }
+    return true;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -35,6 +70,10 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
 
       if (!supabase) {
         setError('Database connection failed. Please try again later.');
+        return;
+      }
+
+      if (!validateLinks()) {
         return;
       }
 

--- a/components/dashboard/ProfileForm.tsx
+++ b/components/dashboard/ProfileForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { FormField } from '@/components/ui/FormField';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
+import { ProfileHeader } from '@/components/profile/ProfileHeader';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { Artist } from '@/types/db';
 
@@ -22,6 +23,8 @@ export function ProfileForm({ artist, onUpdate }: ProfileFormProps) {
     tagline: artist.tagline || '',
     image_url: artist.image_url || '',
   });
+
+  const previewArtist: Artist = { ...artist, ...formData };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -66,45 +69,54 @@ export function ProfileForm({ artist, onUpdate }: ProfileFormProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <FormField label="Artist Name" error={error}>
-        <Input
-          type="text"
-          value={formData.name}
-          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          placeholder="Your Artist Name"
-          required
-        />
-      </FormField>
+    <div className="grid gap-8 md:grid-cols-2">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormField label="Artist Name" error={error}>
+          <Input
+            type="text"
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            placeholder="Your Artist Name"
+            required
+          />
+        </FormField>
 
-      <FormField label="Tagline" error={error}>
-        {/* Assuming Textarea is removed or replaced, using Input for now */}
-        <Input
-          type="text"
-          value={formData.tagline}
-          onChange={(e) =>
-            setFormData({ ...formData, tagline: e.target.value })
-          }
-          placeholder="Share your story, music journey, or what inspires you..."
-        />
-      </FormField>
+        <FormField label="Tagline" error={error}>
+          {/* Assuming Textarea is removed or replaced, using Input for now */}
+          <Input
+            type="text"
+            value={formData.tagline}
+            onChange={(e) =>
+              setFormData({ ...formData, tagline: e.target.value })
+            }
+            placeholder="Share your story, music journey, or what inspires you..."
+          />
+        </FormField>
 
-      <Button
-        type="submit"
-        disabled={loading}
-        variant="primary"
-        className="w-full"
+        <Button
+          type="submit"
+          disabled={loading}
+          variant="primary"
+          className="w-full"
+        >
+          {loading ? 'Updating...' : 'Update Profile'}
+        </Button>
+
+        {success && (
+          <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-3">
+            <p className="text-sm text-green-600 dark:text-green-400">
+              Profile updated successfully!
+            </p>
+          </div>
+        )}
+      </form>
+
+      <aside
+        aria-label="Profile preview"
+        className="rounded-lg border border-gray-200 p-6 dark:border-gray-700"
       >
-        {loading ? 'Updating...' : 'Update Profile'}
-      </Button>
-
-      {success && (
-        <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-3">
-          <p className="text-sm text-green-600 dark:text-green-400">
-            Profile updated successfully!
-          </p>
-        </div>
-      )}
-    </form>
+        <ProfileHeader artist={previewArtist} />
+      </aside>
+    </div>
   );
 }

--- a/components/dashboard/SocialsForm.tsx
+++ b/components/dashboard/SocialsForm.tsx
@@ -53,6 +53,34 @@ export function SocialsForm({ artist }: SocialsFormProps) {
     fetchSocialLinks();
   }, [artist.id, getAuthenticatedClient]);
 
+  const validateLinks = () => {
+    const domainMap: Record<string, string | null> = {
+      instagram: 'instagram.com',
+      twitter: 'twitter.com',
+      tiktok: 'tiktok.com',
+      youtube: 'youtube.com',
+      facebook: 'facebook.com',
+      linkedin: 'linkedin.com',
+      website: null,
+    };
+
+    for (const link of socialLinks) {
+      if (!link.url.trim()) continue;
+      try {
+        const url = new URL(link.url);
+        const expected = domainMap[link.platform];
+        if (expected && !url.hostname.toLowerCase().includes(expected)) {
+          setError(`Please enter a valid ${link.platform} URL.`);
+          return false;
+        }
+      } catch {
+        setError('Please enter valid URLs.');
+        return false;
+      }
+    }
+    return true;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -64,6 +92,10 @@ export function SocialsForm({ artist }: SocialsFormProps) {
 
       if (!supabase) {
         setError('Database connection failed. Please try again later.');
+        return;
+      }
+
+      if (!validateLinks()) {
         return;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@playwright/test": "^1.40.1",
@@ -131,6 +132,19 @@
         "bidi-js": "^1.0.3",
         "css-tree": "^2.3.1",
         "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@playwright/test": "^1.40.1",

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from './setup';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Accessibility checks @a11y', () => {
+  test('home page has no accessibility violations', async ({ page }) => {
+    await page.goto('/');
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('artist profile has no accessibility violations', async ({ page }) => {
+    await page.goto('/dualipa');
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/tests/e2e/home-responsive.spec.ts
+++ b/tests/e2e/home-responsive.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from './setup';
+
+test.describe('Home page responsive layout', () => {
+  const sizes = [
+    { name: 'mobile', width: 375, height: 667 },
+    { name: 'desktop', width: 1280, height: 800 },
+  ];
+
+  for (const size of sizes) {
+    test(`renders correctly on ${size.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: size.width, height: size.height });
+      await page.goto('/');
+      await expect(
+        page.getByText(
+          'Connect your music, social media, and merch in one link'
+        )
+      ).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- preview profile edits live in dashboard
- validate social and streaming links before save
- add accessibility and responsive playwright tests

## Testing
- `npm run lint`
- `npm test`
- `npx playwright test tests/e2e/accessibility.spec.ts tests/e2e/home-responsive.spec.ts` *(fails: chromium.launch: unable to download browser)*

------
https://chatgpt.com/codex/tasks/task_e_6893c68bf08483278c4d4bf2128367ff