### PR TITLE
fix: remove invalid parameters from create-pull-request action

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -160,8 +160,6 @@ jobs:
           draft: false
           maintainer-can-modify: true
           path: .
-          committer-email: 41898282+github-actions[bot]@users.noreply.github.com
-          author-email: 35063371+itstimwhite@users.noreply.github.com
 
       - name: Debug PR creation
         if: steps.check-ahead.outputs.develop_ahead == 'true'


### PR DESCRIPTION
## Workflow Fix

### Problem
The promote job was failing because the  action was receiving invalid parameters:
-  and  are not supported parameters
- These were causing the action to fail with validation errors

### Solution
- Removed the invalid  and  parameters
- The action already handles email addresses through the  and  fields
- This should fix the promote job failures

### Changes
- Updated  to remove invalid parameters
- The workflow should now run successfully without validation errors