### PR TITLE
fix: remove --json flag from GitHub CLI commands

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -142,7 +142,7 @@ jobs:
           git push origin auto-promote/preview
           
           # Create PR using GitHub CLI
-          PR_URL=$(gh pr create \
+          gh pr create \
             --title "Auto-promote: develop → preview" \
             --body "🤖 **Automated Promotion**
 
@@ -156,17 +156,15 @@ jobs:
           **Auto-merge enabled** - This PR will be automatically merged when all checks pass." \
             --base preview \
             --head auto-promote/preview \
-            --label "ci,promotion,auto-merge" \
-            --json url --jq .url)
+            --label "ci,promotion,auto-merge"
           
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          echo "PR created: $PR_URL"
+          echo "PR created successfully"
 
       - name: Enable auto-merge
-        if: steps.check-ahead.outputs.develop_ahead == 'true' && steps.create_pr.outputs.pr_url != ''
+        if: steps.check-ahead.outputs.develop_ahead == 'true'
         run: |
-          # Extract PR number from URL
-          PR_NUMBER=$(echo "${{ steps.create_pr.outputs.pr_url }}" | sed 's/.*\/pull\///')
+          # Get the PR number for the auto-promote/preview branch
+          PR_NUMBER=$(gh pr list --head auto-promote/preview --json number --jq '.[0].number')
           echo "Enabling auto-merge for PR #$PR_NUMBER"
           
           # Enable auto-merge

--- a/.github/workflows/preview-ci.yml
+++ b/.github/workflows/preview-ci.yml
@@ -135,7 +135,7 @@ jobs:
           git push origin auto-promote/main
           
           # Create PR using GitHub CLI
-          PR_URL=$(gh pr create \
+          gh pr create \
             --title "Auto-promote: preview → main" \
             --body "🤖 **Automated Promotion**
 
@@ -149,17 +149,15 @@ jobs:
           **Auto-merge enabled** - This PR will be automatically merged when all checks pass." \
             --base main \
             --head auto-promote/main \
-            --label "ci,promotion,auto-merge" \
-            --json url --jq .url)
+            --label "ci,promotion,auto-merge"
           
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          echo "PR created: $PR_URL"
+          echo "PR created successfully"
 
       - name: Enable auto-merge
-        if: steps.check-ahead.outputs.preview_ahead == 'true' && steps.create_pr.outputs.pr_url != ''
+        if: steps.check-ahead.outputs.preview_ahead == 'true'
         run: |
-          # Extract PR number from URL
-          PR_NUMBER=$(echo "${{ steps.create_pr.outputs.pr_url }}" | sed 's/.*\/pull\///')
+          # Get the PR number for the auto-promote/main branch
+          PR_NUMBER=$(gh pr list --head auto-promote/main --json number --jq '.[0].number')
           echo "Enabling auto-merge for PR #$PR_NUMBER"
           
           # Enable auto-merge


### PR DESCRIPTION
Fix GitHub CLI compatibility issue in workflow by removing unsupported --json flag and using alternative approach to get PR number for auto-merge.