### PR TITLE
feat: add tip jar route with stripe

### DIFF
--- a/app/[handle]/tip/page.tsx
+++ b/app/[handle]/tip/page.tsx
@@ -1,0 +1,206 @@
+import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
+import { createServerClient } from '@/lib/supabase-server';
+import { Artist, SocialLink } from '@/types/db';
+import { Container } from '@/components/site/Container';
+import { ProfileHeader } from '@/components/profile/ProfileHeader';
+import { TipJar } from '@/components/profile/TipJar';
+import { SocialBar } from '@/components/organisms/SocialBar';
+import { ProfileFooter } from '@/components/profile/ProfileFooter';
+import { ArtistSEO } from '@/components/seo/ArtistSEO';
+import { ThemeToggle } from '@/components/site/ThemeToggle';
+
+interface ProfilePageProps {
+  params: Promise<{
+    handle: string;
+  }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ProfilePageProps): Promise<Metadata> {
+  const { handle } = await params;
+  const supabase = await createServerClient();
+
+  if (!supabase) {
+    return {
+      title: 'Artist Not Found',
+    };
+  }
+
+  const { data: artist } = await supabase
+    .from('artists')
+    .select('name, tagline, image_url, is_verified')
+    .eq('handle', handle)
+    .eq('published', true)
+    .single();
+
+  if (!artist) {
+    return {
+      title: 'Artist Not Found',
+    };
+  }
+
+  const title = `${artist.name} - Music Artist`;
+  const description =
+    artist.tagline ||
+    `Listen to ${artist.name} on Spotify and other platforms.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+      images: artist.image_url
+        ? [
+            {
+              url: artist.image_url,
+              width: 400,
+              height: 400,
+              alt: `${artist.name} - Music Artist Profile Photo`,
+            },
+          ]
+        : [],
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+      images: artist.image_url ? [artist.image_url] : [],
+    },
+    other: {
+      'profile:username': handle,
+      ...(artist.is_verified && { 'profile:verified': 'true' }),
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  const supabase = await createServerClient();
+
+  if (!supabase) {
+    return [];
+  }
+
+  const { data: artists } = await supabase
+    .from('artists')
+    .select('handle')
+    .eq('published', true);
+
+  return (
+    artists?.map((artist) => ({
+      handle: artist.handle,
+    })) || []
+  );
+}
+
+function generateStructuredData(artist: Artist, socialLinks: SocialLink[]) {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: artist.name,
+    url: `https://jovie.co/${artist.handle}`,
+    image: artist.image_url,
+    description: artist.tagline,
+    jobTitle: 'Music Artist',
+    worksFor: {
+      '@type': 'Organization',
+      name: 'Music Industry',
+    },
+    knowsAbout: ['Music', 'Art', 'Entertainment'],
+    hasOccupation: {
+      '@type': 'Occupation',
+      name: 'Music Artist',
+      occupationLocation: {
+        '@type': 'Place',
+        name: 'Global',
+      },
+    },
+    // Add social media links
+    sameAs: socialLinks.map((link) => link.url),
+    // Add verification status
+    ...(artist.is_verified && {
+      additionalProperty: {
+        '@type': 'PropertyValue',
+        name: 'verified',
+        value: true,
+      },
+    }),
+  };
+
+  return structuredData;
+}
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+  const { handle } = await params;
+  const supabase = await createServerClient();
+
+  if (!supabase) {
+    notFound();
+  }
+
+  // Fetch artist and social links in a single query to reduce latency
+  const { data, error } = await supabase
+    .from('artists')
+    .select('*, social_links(*)')
+    .eq('handle', handle)
+    .eq('published', true)
+    .single();
+
+  if (error || !data) {
+    notFound();
+  }
+
+  const { social_links: socialLinks = [], ...artist } = data as Artist & {
+    social_links: SocialLink[];
+  };
+
+  // Generate structured data
+  const structuredData = generateStructuredData(artist, socialLinks);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData),
+        }}
+      />
+      <ArtistSEO artist={artist} socialLinks={socialLinks} />
+      <div className="min-h-screen bg-white dark:bg-gray-900 transition-colors duration-200">
+        <Container>
+          {/* Theme Toggle */}
+          <div className="absolute top-4 right-4 z-10">
+            <ThemeToggle />
+          </div>
+
+          <div className="flex min-h-screen flex-col py-12">
+            <div className="flex-1 flex flex-col items-center justify-center">
+              <div className="w-full max-w-md space-y-8">
+                <ProfileHeader artist={artist} />
+
+                <div className="flex justify-center">
+                  <TipJar handle={artist.handle} artistName={artist.name} />
+                </div>
+
+                <SocialBar
+                  handle={artist.handle}
+                  artistName={artist.name}
+                  socialLinks={socialLinks}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-center">
+              <div className="w-full max-w-md">
+                <ProfileFooter artist={artist} />
+              </div>
+            </div>
+          </div>
+        </Container>
+      </div>
+    </>
+  );
+}

--- a/app/api/capture-tip/route.ts
+++ b/app/api/capture-tip/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { headers } from 'next/headers';
+import Stripe from 'stripe';
+import { createServerClient } from '@/lib/supabase-server';
+
+export async function POST(req: NextRequest) {
+  try {
+    if (
+      !process.env.STRIPE_SECRET_KEY ||
+      !process.env.STRIPE_TIP_WEBHOOK_SECRET
+    ) {
+      return NextResponse.json(
+        { error: 'Stripe not configured' },
+        { status: 500 }
+      );
+    }
+
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+    const body = await req.text();
+    const headersList = await headers();
+    const signature = headersList.get('stripe-signature');
+
+    if (!signature) {
+      return NextResponse.json({ error: 'No signature' }, { status: 400 });
+    }
+
+    let event: Stripe.Event;
+
+    try {
+      event = stripe.webhooks.constructEvent(
+        body,
+        signature,
+        process.env.STRIPE_TIP_WEBHOOK_SECRET
+      );
+    } catch (err) {
+      console.error('Invalid signature', err);
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+    }
+
+    if (event.type === 'payment_intent.succeeded') {
+      const pi = event.data.object as Stripe.PaymentIntent;
+      const supabase = await createServerClient();
+      if (supabase) {
+        const charge = (
+          pi as Stripe.PaymentIntent & { charges?: { data: Stripe.Charge[] } }
+        ).charges?.data?.[0];
+        await supabase.from('tips').insert({
+          artist_id: pi.metadata.handle,
+          amount_cents: pi.amount_received,
+          currency: pi.currency?.toUpperCase(),
+          payment_intent: pi.id,
+          contact_email: charge?.billing_details?.email,
+          contact_phone: charge?.billing_details?.phone,
+        });
+      }
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error('Tip webhook error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/create-tip-intent/route.ts
+++ b/app/api/create-tip-intent/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+export async function POST(req: NextRequest) {
+  try {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return NextResponse.json(
+        { error: 'Stripe not configured' },
+        { status: 500 }
+      );
+    }
+
+    const { amount, handle } = await req.json();
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: amount * 100,
+      currency: 'usd',
+      automatic_payment_methods: { enabled: true },
+      metadata: { handle, amount },
+    });
+
+    return NextResponse.json({ clientSecret: paymentIntent.client_secret });
+  } catch (error) {
+    console.error('Create tip intent error:', error);
+    return NextResponse.json(
+      { error: 'Failed to create tip' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/profile/TipJar.tsx
+++ b/components/profile/TipJar.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { loadStripe, Stripe, PaymentRequest } from '@stripe/stripe-js';
+import Image from 'next/image';
+import { Button } from '@/components/ui/Button';
+
+interface TipJarProps {
+  handle: string;
+  artistName: string;
+}
+
+const AMOUNTS = [2, 5, 10];
+
+export function TipJar({ handle, artistName }: TipJarProps) {
+  const [stripe, setStripe] = useState<Stripe | null>(null);
+  const [paymentRequest, setPaymentRequest] = useState<PaymentRequest | null>(
+    null
+  );
+  const [supported, setSupported] = useState(false);
+  const [loading, setLoading] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function init() {
+      const key = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+      if (!key) return;
+      const s = await loadStripe(key);
+      if (!s) return;
+      const pr = s.paymentRequest({
+        country: 'US',
+        currency: 'usd',
+        total: { label: artistName, amount: 0 },
+        requestPayerEmail: true,
+        requestPayerName: true,
+        requestPayerPhone: true,
+      });
+      const result = await pr.canMakePayment();
+      if (result) {
+        setSupported(true);
+        setPaymentRequest(pr);
+        setStripe(s);
+      }
+    }
+    init();
+  }, [artistName]);
+
+  const handleTip = async (amount: number) => {
+    if (!stripe || !paymentRequest) return;
+    setLoading(amount);
+    paymentRequest.show();
+    try {
+      const res = await fetch('/api/create-tip-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount, handle }),
+      });
+      if (!res.ok) throw new Error('Network response was not ok');
+      window.alert(`Thanks for the $${amount} tip 🎉`);
+    } catch (err) {
+      console.error('Tip failed', err);
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  if (!supported) {
+    return (
+      <div className="text-center space-y-4">
+        <Image
+          src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(
+            typeof window !== 'undefined' ? window.location.href : ''
+          )}`}
+          alt="Scan to tip"
+          className="mx-auto h-48 w-48"
+          width={192}
+          height={192}
+        />
+        <p className="text-sm text-gray-600">Scan to tip via Apple Pay</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-sm space-y-3">
+      {AMOUNTS.map((amount) => (
+        <Button
+          key={amount}
+          onClick={() => handleTip(amount)}
+          className="w-full"
+          size="lg"
+          disabled={loading !== null}
+        >
+          {loading === amount ? 'Processing…' : `$${amount} Tip`}
+        </Button>
+      ))}
+      <p className="mt-2 text-center text-xs text-gray-500">
+        Tips are non-refundable
+      </p>
+    </div>
+  );
+}
+
+export default TipJar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.1",
         "@segment/analytics-next": "^1.68.0",
+        "@stripe/stripe-js": "^7.8.0",
         "@supabase/supabase-js": "^2.39.0",
         "@vercel/analytics": "^1.5.0",
         "clsx": "^2.1.0",
@@ -3432,6 +3433,15 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.8.0.tgz",
+      "integrity": "sha512-DNXRfYUgkZlrniQORbA/wH8CdFRhiBSE0R56gYU0V5vvpJ9WZwvGrz9tBAZmfq2aTgw6SK7mNpmTizGzLWVezw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.1",
     "@segment/analytics-next": "^1.68.0",
+    "@stripe/stripe-js": "^7.8.0",
     "@supabase/supabase-js": "^2.39.0",
     "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.0",

--- a/tests/unit/TipJar.test.tsx
+++ b/tests/unit/TipJar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { TipJar } from '@/components/profile/TipJar';
+import { loadStripe } from '@stripe/stripe-js';
+
+vi.mock('@stripe/stripe-js', () => ({
+  loadStripe: vi.fn(),
+}));
+
+const mockedLoadStripe = loadStripe as unknown as ReturnType<typeof vi.fn>;
+
+describe('TipJar', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+  });
+
+  it('renders tip buttons on supported devices', async () => {
+    const show = vi.fn();
+    const paymentRequest = {
+      canMakePayment: vi.fn().mockResolvedValue(true),
+      show,
+    };
+    mockedLoadStripe.mockResolvedValue({
+      paymentRequest: () => paymentRequest,
+    });
+
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test';
+
+    render(<TipJar handle="tim" artistName="Tim" />);
+
+    expect(await screen.findByText('$2 Tip')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('$2 Tip'));
+    expect(show).toHaveBeenCalled();
+  });
+
+  it('renders QR fallback when PaymentRequest unsupported', async () => {
+    const paymentRequest = {
+      canMakePayment: vi.fn().mockResolvedValue(null),
+    };
+    mockedLoadStripe.mockResolvedValue({
+      paymentRequest: () => paymentRequest,
+    });
+
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test';
+
+    render(<TipJar handle="tim" artistName="Tim" />);
+
+    expect(
+      await screen.findByText('Scan to tip via Apple Pay')
+    ).toBeInTheDocument();
+  });
+});

--- a/types/db.ts
+++ b/types/db.ts
@@ -62,3 +62,14 @@ export interface Subscription {
   revenuecat_id?: string;
   created_at: string;
 }
+
+export interface Tip {
+  id: string;
+  artist_id: string;
+  contact_email?: string;
+  contact_phone?: string;
+  amount_cents: number;
+  currency: string;
+  payment_intent: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- add tip jar profile route with Apple/Google Pay buttons
- capture tip payments and contact info via Stripe webhook
- test mobile PaymentRequest flow and desktop QR fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f2d86f3c832798561b0c74554ad2