### PR TITLE
Self-host Inter font and add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: Build
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    uses: ./.github/workflows/_reusable-build.yml

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,10 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import { ClientProviders } from '@/components/providers/ClientProviders';
 import { APP_NAME, APP_URL } from '@/constants/app';
 import '@/styles/globals.css';
 
 // Bypass static rendering for now to fix build issues
 export const dynamic = 'force-dynamic';
-
-// Load Inter font with next/font
-const inter = Inter({
-  subsets: ['latin'],
-  weight: ['400', '700'],
-  display: 'swap',
-  variable: '--font-inter',
-});
 
 export const metadata: Metadata = {
   title: {
@@ -103,7 +94,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning className={inter.variable}>
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="dns-prefetch" href="https://i.scdn.co" />
         <link rel="dns-prefetch" href="https://api.spotify.com" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.28.1",
+        "@fontsource/inter": "^5.2.6",
         "@headlessui/react": "^2.2.7",
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.1",
@@ -1811,6 +1812,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.6.tgz",
+      "integrity": "sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@gitbeaker/core": {
       "version": "38.12.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.28.1",
+    "@fontsource/inter": "^5.2.6",
     "@headlessui/react": "^2.2.7",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.1",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,8 +1,16 @@
 @import 'tailwindcss';
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/700.css';
 
 @plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:is(.dark *));
+
+@layer base {
+  :root {
+    --font-inter: 'Inter';
+  }
+}
 
 @theme {
   --font-sans:


### PR DESCRIPTION
## Summary
- host Inter locally via `@fontsource` and remove Google font dependency
- add global font variable so `font-sans` resolves offline
- introduce GitHub Actions workflow that runs full build on every push/PR

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c6c2f8f48327a8e77c700ed8b55e