### PR TITLE
fix: add GH_TOKEN environment variable to CI workflows

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -106,6 +106,8 @@ jobs:
     needs: build
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/preview-ci.yml
+++ b/.github/workflows/preview-ci.yml
@@ -99,6 +99,8 @@ jobs:
     needs: build
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fix GitHub CLI authentication issues in auto-promote workflows by adding GH_TOKEN environment variable.