### PR TITLE
fix: remove non-existent labels from auto-promote PRs

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -157,8 +157,7 @@ jobs:
 
           **Auto-merge enabled** - This PR will be automatically merged when all checks pass." \
             --base preview \
-            --head auto-promote/preview \
-            --label "ci,promotion,auto-merge"
+            --head auto-promote/preview
           
           echo "PR created successfully"
 

--- a/.github/workflows/preview-ci.yml
+++ b/.github/workflows/preview-ci.yml
@@ -150,8 +150,7 @@ jobs:
 
           **Auto-merge enabled** - This PR will be automatically merged when all checks pass." \
             --base main \
-            --head auto-promote/main \
-            --label "ci,promotion,auto-merge"
+            --head auto-promote/main
           
           echo "PR created successfully"
 


### PR DESCRIPTION
Remove labels that don't exist in the repository to fix auto-promote PR creation failures.