### PR TITLE
feat: add desktop qr overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,4 @@ REVENUECAT_API_KEY=your_revenuecat_api_key_here
 
 # ===== Feature Flags =====
 NEXT_PUBLIC_FEATURE_TIPS=true
+NEXT_PUBLIC_FEATURE_DESKTOP_QR=false

--- a/app/[handle]/layout.tsx
+++ b/app/[handle]/layout.tsx
@@ -1,0 +1,16 @@
+import DesktopQrOverlay from '@/components/organisms/DesktopQrOverlay';
+
+export default function ProfileLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { handle: string };
+}) {
+  return (
+    <>
+      {children}
+      <DesktopQrOverlay handle={params.handle} />
+    </>
+  );
+}

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -38,9 +38,9 @@ export function Analytics() {
   }, [pathname]);
 
   useEffect(() => {
+    if (trackedRef.current) return;
     try {
       if (typeof window === 'undefined') return;
-      if (trackedRef.current) return;
       if (searchParams.get('src') === 'qr_desktop') {
         const segments = pathname.split('/').filter(Boolean);
         if (segments.length > 0) {

--- a/components/organisms/DesktopQrOverlay.tsx
+++ b/components/organisms/DesktopQrOverlay.tsx
@@ -26,11 +26,12 @@ export default function DesktopQrOverlay({ handle }: DesktopQrOverlayProps) {
     url.searchParams.set('src', 'qr_desktop');
     return url.toString();
   }, []);
-  const qrSize =
-    typeof window !== 'undefined' &&
-    window.matchMedia('(min-width:1024px)').matches
-      ? 120
-      : 96;
+  const qrSize = useMemo(() => {
+    if (typeof window !== 'undefined' && window.matchMedia('(min-width:1024px)').matches) {
+      return 120;
+    }
+    return 96;
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/components/organisms/DesktopQrOverlay.tsx
+++ b/components/organisms/DesktopQrOverlay.tsx
@@ -72,19 +72,22 @@ export default function DesktopQrOverlay({ handle }: DesktopQrOverlayProps) {
       }
     };
 
-    let timer: ReturnType<typeof window.requestIdleCallback> | ReturnType<typeof window.setTimeout>;
+    // Track both the timer id and the method used
+    let timerInfo:
+      | { type: 'idle'; id: ReturnType<typeof window.requestIdleCallback> }
+      | { type: 'timeout'; id: ReturnType<typeof window.setTimeout> };
     if (window.requestIdleCallback) {
-      timer = window.requestIdleCallback(show);
+      timerInfo = { type: 'idle', id: window.requestIdleCallback(show) };
     } else {
-      timer = window.setTimeout(show, 1500);
+      timerInfo = { type: 'timeout', id: window.setTimeout(show, 1500) };
     }
     window.addEventListener('scroll', scrollHandler);
 
     return () => {
-      if (window.cancelIdleCallback) {
-        window.cancelIdleCallback(timer);
-      } else {
-        clearTimeout(timer);
+      if (timerInfo.type === 'idle' && window.cancelIdleCallback) {
+        window.cancelIdleCallback(timerInfo.id);
+      } else if (timerInfo.type === 'timeout') {
+        clearTimeout(timerInfo.id);
       }
       window.removeEventListener('scroll', scrollHandler);
       window.removeEventListener('touchstart', touchHandler);

--- a/components/organisms/DesktopQrOverlay.tsx
+++ b/components/organisms/DesktopQrOverlay.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { XMarkIcon, DevicePhoneMobileIcon } from '@heroicons/react/24/outline';
+import { FEATURE_FLAGS } from '@/constants/app';
+import { track } from '@/lib/analytics';
+
+interface DesktopQrOverlayProps {
+  handle: string;
+}
+
+const HIDE_KEY = 'jovie_hide_qr';
+const HIDE_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export default function DesktopQrOverlay({ handle }: DesktopQrOverlayProps) {
+  const [visible, setVisible] = useState(false);
+  const [showIcon, setShowIcon] = useState(false);
+  const [QRCode, setQRCode] = useState<React.ComponentType<{
+    value: string;
+    size: number;
+  }> | null>(null);
+  const hasShownRef = useRef(false);
+  const qrUrl = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    const url = new URL(window.location.href);
+    url.searchParams.set('src', 'qr_desktop');
+    return url.toString();
+  }, []);
+  const qrSize =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(min-width:1024px)').matches
+      ? 120
+      : 96;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!FEATURE_FLAGS.desktopQr) return;
+
+    const hiddenUntil = Number(localStorage.getItem(HIDE_KEY) || 0);
+    if (hiddenUntil) {
+      if (Date.now() < hiddenUntil) return;
+      localStorage.removeItem(HIDE_KEY);
+    }
+
+    // Do not show on mobile or when reduced motion / print
+    const isDesktop = window.matchMedia('(min-width: 768px)').matches;
+    const prefersReduced = window.matchMedia(
+      '(prefers-reduced-motion: reduce)'
+    ).matches;
+    const isPrint = window.matchMedia('print').matches;
+    if (!isDesktop || prefersReduced || isPrint) return;
+
+    let touched = false;
+    const touchHandler = () => {
+      touched = true;
+    };
+    window.addEventListener('touchstart', touchHandler, { passive: true });
+
+    const show = () => {
+      if (touched || hasShownRef.current) return;
+      hasShownRef.current = true;
+      setVisible(true);
+      import('qrcode.react').then((mod) => setQRCode(() => mod.default));
+      track('desktop_qr_shown', { profile: handle });
+    };
+
+    const scrollHandler = () => {
+      if (window.scrollY > window.innerHeight * 0.5) {
+        show();
+        window.removeEventListener('scroll', scrollHandler);
+      }
+    };
+
+    let timer: number;
+    if (window.requestIdleCallback) {
+      timer = window.requestIdleCallback(show);
+    } else {
+      timer = window.setTimeout(show, 1500);
+    }
+    window.addEventListener('scroll', scrollHandler);
+
+    return () => {
+      if (window.cancelIdleCallback) {
+        window.cancelIdleCallback(timer);
+      } else {
+        clearTimeout(timer);
+      }
+      window.removeEventListener('scroll', scrollHandler);
+      window.removeEventListener('touchstart', touchHandler);
+    };
+  }, [handle]);
+
+  const dismiss = () => {
+    setVisible(false);
+    setShowIcon(true);
+    localStorage.setItem(HIDE_KEY, String(Date.now() + HIDE_DURATION));
+  };
+
+  const reopen = () => {
+    localStorage.removeItem(HIDE_KEY);
+    setShowIcon(false);
+    setVisible(true);
+    if (!QRCode) {
+      import('qrcode.react').then((mod) => setQRCode(() => mod.default));
+    }
+    track('desktop_qr_shown', { profile: handle });
+  };
+
+  if (!visible && !showIcon) return null;
+
+  return (
+    <>
+      {visible && QRCode && (
+        <div className="fixed bottom-4 right-4 z-50 p-4 rounded-lg shadow-lg backdrop-blur-sm bg-white/80 dark:bg-gray-800/80 flex flex-col items-center gap-2 transition-opacity">
+          <button
+            aria-label="Dismiss"
+            className="absolute top-1 right-1 text-gray-500 hover:text-gray-700"
+            onClick={dismiss}
+          >
+            <XMarkIcon className="w-4 h-4" />
+          </button>
+          <QRCode
+            value={qrUrl}
+            size={qrSize}
+            aria-label="Scan to view on mobile"
+          />
+          <p className="text-xs text-gray-700 dark:text-gray-200">
+            View on mobile
+          </p>
+        </div>
+      )}
+      {showIcon && (
+        <button
+          aria-label="Show QR"
+          onClick={reopen}
+          className="fixed bottom-4 right-4 z-40 p-2 rounded-full shadow-lg backdrop-blur-sm bg-white/80 dark:bg-gray-800/80 text-gray-700 dark:text-gray-200"
+        >
+          <DevicePhoneMobileIcon className="w-5 h-5" />
+        </button>
+      )}
+    </>
+  );
+}

--- a/components/organisms/DesktopQrOverlay.tsx
+++ b/components/organisms/DesktopQrOverlay.tsx
@@ -72,7 +72,7 @@ export default function DesktopQrOverlay({ handle }: DesktopQrOverlayProps) {
       }
     };
 
-    let timer: number;
+    let timer: ReturnType<typeof window.requestIdleCallback> | ReturnType<typeof window.setTimeout>;
     if (window.requestIdleCallback) {
       timer = window.requestIdleCallback(show);
     } else {

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -3,3 +3,4 @@
 
 export * from './Header';
 export * from './SocialBar';
+export { default as DesktopQrOverlay } from './DesktopQrOverlay';

--- a/constants/app.ts
+++ b/constants/app.ts
@@ -15,6 +15,7 @@ export const ANALYTICS = {
 // Feature flags
 const waitlistEnabled = process.env.NEXT_PUBLIC_WAITLIST_ENABLED === 'true';
 const artistSearchEnabled = !waitlistEnabled;
+const desktopQr = process.env.NEXT_PUBLIC_FEATURE_DESKTOP_QR === 'true';
 
 export const FEATURE_FLAGS = {
   // Control waitlist mode via environment variable
@@ -23,6 +24,7 @@ export const FEATURE_FLAGS = {
   waitlistEnabled,
   // Artist search is enabled when waitlist mode is disabled
   artistSearchEnabled,
+  desktopQr,
 };
 export const LEGAL = {
   privacyPath: '/legal/privacy',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "dotenv": "^17.2.1",
         "next": "^15.4.5",
         "next-themes": "^0.4.6",
+        "qrcode.react": "^3.2.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hook-form": "^7.62.0",
@@ -11768,6 +11769,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^17.2.1",
     "next": "^15.4.5",
     "next-themes": "^0.4.6",
+    "qrcode.react": "^3.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.62.0",

--- a/tests/unit/DesktopQrOverlay.test.tsx
+++ b/tests/unit/DesktopQrOverlay.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from '@testing-library/react';
+import DesktopQrOverlay from '@/components/organisms/DesktopQrOverlay';
+import { track } from '@/lib/analytics';
+
+vi.mock('@/constants/app', () => ({ FEATURE_FLAGS: { desktopQr: true } }));
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('qrcode.react', () => ({
+  default: ({ value }: { value: string }) => (
+    <div data-testid="qr" data-value={value} />
+  ),
+}));
+
+describe('DesktopQrOverlay', () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalRequestIdle = window.requestIdleCallback;
+  const originalCancelIdle = window.cancelIdleCallback;
+
+  const setDesktop = () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches:
+        query.includes('min-width: 768px') ||
+        query.includes('min-width:1024px'),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })) as any;
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    (track as any).mockClear();
+    setDesktop();
+    window.requestIdleCallback = ((cb: IdleRequestCallback) => {
+      cb({} as IdleDeadline);
+      return 1;
+    }) as any;
+    window.cancelIdleCallback = (() => {}) as any;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    window.requestIdleCallback = originalRequestIdle;
+    window.cancelIdleCallback = originalCancelIdle;
+    cleanup();
+  });
+
+  it('renders QR after delay on desktop and tracks event', async () => {
+    render(<DesktopQrOverlay handle="test" />);
+    await waitFor(() => screen.getByText('View on mobile'));
+    expect(screen.getByText('View on mobile')).toBeInTheDocument();
+    expect(screen.getByTestId('qr').getAttribute('data-value')).toContain(
+      'src=qr_desktop'
+    );
+    expect(track).toHaveBeenCalledWith('desktop_qr_shown', { profile: 'test' });
+  });
+
+  it('persists dismissal using localStorage', async () => {
+    render(<DesktopQrOverlay handle="test" />);
+    const dismissButton = await screen.findByLabelText('Dismiss');
+    fireEvent.click(dismissButton);
+    expect(localStorage.getItem('jovie_hide_qr')).toBeTruthy();
+    cleanup();
+    render(<DesktopQrOverlay handle="test" />);
+    expect(screen.queryByText('View on mobile')).toBeNull();
+  });
+});

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 
 // Import the individual atomic components to test them directly
@@ -7,6 +7,7 @@ import { NavLink } from '@/components/atoms/NavLink';
 import { AuthActions } from '@/components/molecules/AuthActions';
 
 describe('Atomic Design Structure', () => {
+  beforeEach(cleanup);
   afterEach(cleanup);
 
   describe('Atoms', () => {

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -7,7 +7,6 @@ import { NavLink } from '@/components/atoms/NavLink';
 import { AuthActions } from '@/components/molecules/AuthActions';
 
 describe('Atomic Design Structure', () => {
-  beforeEach(cleanup);
   afterEach(cleanup);
 
   describe('Atoms', () => {


### PR DESCRIPTION
## Summary
- add desktop QR overlay with lazy-loaded QR generation and localStorage dismissal
- track desktop QR analytics events and scan redirects
- integrate overlay behind feature flag

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893f2f108d88327a2ad7a4c3784d9c5