### PR TITLE
fix: remove invalid edgeConfig property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,13 +3,5 @@
     "app/api/**/*.ts": {
       "maxDuration": 30
     }
-  },
-  "edgeConfig": {
-    "featureFlags": {
-      "waitlistEnabled": false,
-      "artistSearchEnabled": true,
-      "debugBannerEnabled": true,
-      "tipPromoEnabled": true
-    }
   }
 }


### PR DESCRIPTION
## Problem
The vercel.json schema validation was failing with the error: 'should NOT have additional property edgeConfig'

## Solution
- Removed the invalid  property from vercel.json
- Edge Config should be configured through the Vercel dashboard, not in vercel.json
- Feature flags are already properly handled in lib/feature-flags.ts with graceful fallbacks

## Impact
- Fixes CI/CD pipeline schema validation errors
- Maintains all existing functionality
- No breaking changes to feature flag system