### PR TITLE
chore: ignore generated sitemaps to prevent PR conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ next-env.d.ts
 
 
 .env.local
+
+# Ignore generated sitemaps
+public/sitemap*.xml
+public/sitemap*.xml.gz

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://jov.ie/manifest.webmanifest</loc><lastmod>2025-08-07T20:18:00.512Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://jov.ie/robots.txt</loc><lastmod>2025-08-07T20:18:00.513Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://jov.ie/sitemap.xml</loc><lastmod>2025-08-07T20:18:00.513Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<sitemap><loc>https://jov.ie/sitemap-0.xml</loc></sitemap>
-</sitemapindex>


### PR DESCRIPTION
- Add public/sitemap*.xml(.gz) to .gitignore\n- Remove tracked sitemap files\n\nThese files are generated by next-sitemap at build time; excluding from VCS prevents constant merge conflicts.