### PR TITLE
test: align header/AuthActions tests with Sign Up removal

### DIFF
--- a/tests/unit/AuthActions.test.tsx
+++ b/tests/unit/AuthActions.test.tsx
@@ -32,11 +32,11 @@ vi.mock('@clerk/nextjs', () => ({
 describe('AuthActions', () => {
   afterEach(cleanup);
 
-  it('renders sign in and sign up buttons when user is not signed in', () => {
+  it('renders sign in button when user is not signed in', () => {
     render(<AuthActions />);
 
     expect(screen.getByText('Sign in')).toBeInTheDocument();
-    expect(screen.getByText('Sign Up')).toBeInTheDocument();
+    // Sign Up removed from header intentionally
   });
 
   it('renders with correct styling classes', () => {

--- a/tests/unit/Header.test.tsx
+++ b/tests/unit/Header.test.tsx
@@ -33,9 +33,7 @@ describe('Atomic Design Structure', () => {
       expect(
         screen.getByRole('button', { name: 'Sign in' })
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: 'Sign Up' })
-      ).toBeInTheDocument();
+      // Sign up removed from header
 
       // Check that it's properly structured
       const container = screen.getByRole('button', {
@@ -55,7 +53,7 @@ describe('Atomic Design Structure', () => {
         </div>
       );
 
-      // Should have logo, sign in, and sign up links
+      // Should have logo and sign in button (sign up removed)
       expect(screen.getByRole('link', { name: '' })).toHaveAttribute(
         'href',
         '/'
@@ -63,9 +61,7 @@ describe('Atomic Design Structure', () => {
       expect(
         screen.getByRole('button', { name: 'Sign in' })
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: 'Sign Up' })
-      ).toBeInTheDocument();
+      // Sign up removed from header
     });
   });
 });


### PR DESCRIPTION
- Remove Sign Up expectations from Header/AuthActions tests\n- All tests passing locally (179/179)