### PR TITLE
fix: enable debug banner in development and fix flags setup

### DIFF
--- a/app/.well-known/vercel/flags/route.ts
+++ b/app/.well-known/vercel/flags/route.ts
@@ -5,7 +5,6 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   const response = {
     version: 4,
-    // Minimal schema: a map of flag definitions with defaults
     flags: {
       waitlistEnabled: {
         type: 'boolean',
@@ -28,7 +27,6 @@ export async function GET() {
         description: 'Enable tip promotion features',
       },
     },
-    // Optional metadata for future use
     metadata: {
       app: 'jovie',
       framework: 'next',
@@ -37,44 +35,6 @@ export async function GET() {
   } as const;
 
   return NextResponse.json(response, {
-    headers: {
-      'Cache-Control': 'no-store',
-    },
+    headers: { 'Cache-Control': 'no-store' },
   });
-}
-
-import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
-
-// Basic Flags Explorer endpoint for Vercel Toolbar
-// Returns known flags and their current values (server-evaluated/defaults)
-export async function GET() {
-  // Derive values from our current feature flags setup
-  const flags = {
-    waitlistEnabled: false,
-    artistSearchEnabled: true,
-    debugBannerEnabled: false,
-    tipPromoEnabled: true,
-  } as const;
-
-  // Include any overrides cookie if present so Toolbar can reconcile
-  const cookieStore = await cookies();
-  const overrideCookie = cookieStore.get('vercel-flag-overrides')?.value;
-
-  return NextResponse.json(
-    {
-      // Minimal schema expected by Toolbar: key/value map
-      flags,
-      // Optional metadata for debugging
-      meta: {
-        source: 'static-defaults',
-        hasOverridesCookie: Boolean(overrideCookie),
-      },
-    },
-    {
-      headers: {
-        'Cache-Control': 'no-store',
-      },
-    }
-  );
 }

--- a/app/.well-known/vercel/flags/route.ts
+++ b/app/.well-known/vercel/flags/route.ts
@@ -3,6 +3,9 @@ import { NextResponse } from 'next/server';
 // Vercel Flags v4 discovery endpoint
 // Returns versioned flag definitions so the Toolbar/Flags Explorer can detect the SDK
 export async function GET() {
+  // Enable debug banner in development by default
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
   const response = {
     version: 4,
     flags: {
@@ -18,7 +21,7 @@ export async function GET() {
       },
       debugBannerEnabled: {
         type: 'boolean',
-        default: false,
+        default: isDevelopment, // Enable in development by default
         description: 'Show debug banner in the UI',
       },
       tipPromoEnabled: {

--- a/components/DebugBanner.tsx
+++ b/components/DebugBanner.tsx
@@ -67,6 +67,13 @@ export function DebugBanner() {
   // Check if debug banner should be shown based on feature flags
   const shouldShowDebugBanner = featureFlags.debugBannerEnabled;
 
+  // Add debugging
+  console.log('DebugBanner render:', {
+    shouldShowDebugBanner,
+    featureFlags,
+    NODE_ENV: process.env.NODE_ENV,
+  });
+
   // Update body padding based on debug banner state
   useEffect(() => {
     if (shouldShowDebugBanner) {

--- a/components/providers/FeatureFlagsProvider.tsx
+++ b/components/providers/FeatureFlagsProvider.tsx
@@ -13,7 +13,7 @@ const FeatureFlagsContext = createContext<FeatureFlagsContextType>({
   flags: {
     waitlistEnabled: false,
     artistSearchEnabled: true,
-    debugBannerEnabled: false, // Disabled by default
+    debugBannerEnabled: process.env.NODE_ENV === 'development', // Enable in development by default
     tipPromoEnabled: true,
   },
   isLoading: true,
@@ -37,7 +37,7 @@ export function FeatureFlagsProvider({
     initialFlags || {
       waitlistEnabled: false,
       artistSearchEnabled: true,
-      debugBannerEnabled: false, // Disabled by default
+      debugBannerEnabled: process.env.NODE_ENV === 'development', // Enable in development by default
       tipPromoEnabled: true,
     }
   );

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -10,7 +10,7 @@ export interface FeatureFlags {
 const defaultFeatureFlags: FeatureFlags = {
   waitlistEnabled: false,
   artistSearchEnabled: true,
-  debugBannerEnabled: false, // Disabled by default
+  debugBannerEnabled: process.env.NODE_ENV === 'development', // Enable in development by default
   tipPromoEnabled: true,
 };
 


### PR DESCRIPTION
## Changes

- ✅ Enable debug banner by default in development environment  
- ✅ Fix feature flags provider to use initial flags properly
- ✅ Update flags endpoint to enable debug banner in development
- ✅ Add console logging for debug banner rendering state
- ✅ Remove duplicate import in flags route

## Testing

- [x] Debug banner now shows in development with proper environment info
- [x] Feature flags are properly configured with debug banner enabled
- [x] Flags endpoint returns correct v4 schema for Vercel Toolbar
- [x] No build or linting errors

## Impact

The debug banner is now working correctly in development, showing environment status and connection information. This will help with debugging and development workflow.