### PR TITLE
fix: add workflow_dispatch to preview-ci for debugging

### DIFF
--- a/.github/workflows/preview-ci.yml
+++ b/.github/workflows/preview-ci.yml
@@ -3,6 +3,7 @@ name: Preview CI/CD Pipeline
 on:
   push:
     branches: [preview]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Investigation: Preview CI Not Triggering

Adding manual workflow dispatch to preview-ci.yml to debug why the workflow didn't trigger after PR #172 merged to preview.

### Issue:
- PR #172 merged to preview (commit )
- Preview CI/CD Pipeline should have triggered automatically 
- No workflow runs found for that commit
- This breaks the preview → main auto-promotion flow

### This Change:
- Adds  trigger to preview-ci.yml
- Allows manual triggering for debugging/testing
- No functional changes to the workflow logic

### Next Steps:
1. Merge this change
2. Manually trigger preview CI from GitHub Actions tab
3. Test if preview → main promotion works
4. Investigate root cause of auto-trigger failure