### PR TITLE
ci: use Production environment for main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment:
-      name: Main
+      name: Production
       url: https://jov.ie
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Map main deploy to GitHub Environment 'Production' and keep Develop/Preview mapping + URLs.