### PR TITLE
fix: render Clerk pricing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ NEXT_PUBLIC_STATSIG_CLIENT_KEY=client-<your-statsig-client-key>
 # Optional: Clerk billing
 NEXT_PUBLIC_CLERK_BILLING_ENABLED=true
 NEXT_PUBLIC_CLERK_BILLING_GATEWAY=stripe
+NEXT_PUBLIC_CLERK_PRICING_TABLE_ID=your-clerk-pricing-table-id
 
 # Optional: Analytics
 NEXT_PUBLIC_SEGMENT_WRITE_KEY=your-segment-key

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -3,6 +3,13 @@
 import { PricingTable } from '@clerk/nextjs';
 import { Container } from '@/components/site/Container';
 
+// Clerk's PricingTable typings currently omit required configuration props.
+// Cast to any so we can supply them directly until official types are updated.
+const ClerkPricingTable = PricingTable as any;
+
+const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
+const pricingTableId = process.env.NEXT_PUBLIC_CLERK_PRICING_TABLE_ID || '';
+
 export default function PricingPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
@@ -19,7 +26,14 @@ export default function PricingPage() {
           </div>
 
           <div className="max-w-4xl mx-auto">
-            <PricingTable />
+            <ClerkPricingTable
+              publishableKey={publishableKey}
+              pricingTableId={pricingTableId}
+              path="/pricing"
+              redirectUrl="/billing/success"
+              signInUrl="/sign-in"
+              signUpUrl="/sign-up"
+            />
           </div>
 
           <div className="mt-16 text-center">

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -5,6 +5,7 @@ async function globalSetup() {
   Object.assign(process.env, {
     NODE_ENV: 'test',
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_dummy',
+    NEXT_PUBLIC_CLERK_PRICING_TABLE_ID: 'prctbl_dummy',
     CLERK_SECRET_KEY: 'sk_test_dummy',
     NEXT_PUBLIC_SUPABASE_URL: 'https://dummy.supabase.co',
     SUPABASE_SERVICE_ROLE_KEY: 'dummy_key',


### PR DESCRIPTION
## Summary
- pass required configuration to Clerk PricingTable via env vars
- document `NEXT_PUBLIC_CLERK_PRICING_TABLE_ID` and test defaults

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689696a15c208327b9d3b562e9339274