### PR TITLE
feat: add desktop QR overlay for mobile view

### DIFF
--- a/app/[handle]/page.tsx
+++ b/app/[handle]/page.tsx
@@ -9,6 +9,7 @@ import { SocialBar } from '@/components/organisms/SocialBar';
 import { ProfileFooter } from '@/components/profile/ProfileFooter';
 import { ArtistSEO } from '@/components/seo/ArtistSEO';
 import { ThemeToggle } from '@/components/site/ThemeToggle';
+import { DesktopQrOverlay } from '@/components/profile/DesktopQrOverlay';
 
 interface ProfilePageProps {
   params: Promise<{
@@ -203,6 +204,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
             </div>
           </div>
         </Container>
+        <DesktopQrOverlay handle={artist.handle} />
       </div>
     </>
   );

--- a/components/profile/DesktopQrOverlay.tsx
+++ b/components/profile/DesktopQrOverlay.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { XMarkIcon, DevicePhoneMobileIcon } from '@heroicons/react/24/outline';
+
+interface DesktopQrOverlayProps {
+  handle: string;
+}
+
+export function DesktopQrOverlay({ handle }: DesktopQrOverlayProps) {
+  const [show, setShow] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [url, setUrl] = useState('');
+
+  useEffect(() => {
+    const isDesktop = window.matchMedia('(min-width: 768px)').matches;
+    const hasDismissed =
+      localStorage.getItem('viewOnMobileDismissed') === 'true';
+
+    if (isDesktop && !hasDismissed) {
+      setShow(true);
+      setUrl(`${window.location.origin}/${handle}`);
+    } else if (hasDismissed) {
+      setDismissed(true);
+    }
+  }, [handle]);
+
+  const close = () => {
+    setShow(false);
+    setDismissed(true);
+    localStorage.setItem('viewOnMobileDismissed', 'true');
+  };
+
+  const reopen = () => {
+    setShow(true);
+    setDismissed(false);
+  };
+
+  if (!show && !dismissed) return null;
+
+  return show ? (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-center bg-white dark:bg-gray-900 shadow-lg rounded-lg p-4">
+      <button
+        onClick={close}
+        aria-label="Close"
+        className="absolute top-1 right-1 text-gray-400 hover:text-gray-600"
+      >
+        <XMarkIcon className="h-4 w-4" />
+      </button>
+      {url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={`https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${encodeURIComponent(
+            url
+          )}`}
+          alt="Scan to view on mobile"
+          width={120}
+          height={120}
+          className="h-[120px] w-[120px]"
+        />
+      )}
+      <p className="mt-2 text-xs text-gray-600 dark:text-gray-400">
+        View on mobile
+      </p>
+    </div>
+  ) : (
+    <button
+      onClick={reopen}
+      aria-label="View on mobile"
+      className="fixed bottom-4 right-4 z-50 p-2 bg-white dark:bg-gray-900 shadow-lg rounded-full"
+    >
+      <DevicePhoneMobileIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+    </button>
+  );
+}
+
+export default DesktopQrOverlay;

--- a/tests/unit/DesktopQrOverlay.test.tsx
+++ b/tests/unit/DesktopQrOverlay.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { DesktopQrOverlay } from '@/components/profile/DesktopQrOverlay';
+
+function mockMatchMedia(matches: boolean) {
+  return vi.fn().mockImplementation(() => ({
+    matches,
+    media: '',
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe('DesktopQrOverlay', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', mockMatchMedia(true));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders QR code on desktop', async () => {
+    render(<DesktopQrOverlay handle="tim" />);
+    expect(
+      await screen.findByAltText('Scan to view on mobile')
+    ).toBeInTheDocument();
+  });
+
+  it('shows reopen icon after dismiss', async () => {
+    render(<DesktopQrOverlay handle="tim" />);
+    fireEvent.click(await screen.findByLabelText('Close'));
+    expect(screen.queryByAltText('Scan to view on mobile')).toBeNull();
+    expect(screen.getByLabelText('View on mobile')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show a dismissible "View on mobile" QR overlay on artist profiles when viewed on desktop
- integrate overlay into artist profile pages
- test QR overlay rendering and dismissal behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689696854f548327a0ea718927216d18