### PR TITLE
refactor: polish featured artist component

### DIFF
--- a/components/home/FeaturedArtists.tsx
+++ b/components/home/FeaturedArtists.tsx
@@ -40,46 +40,54 @@ async function getFeaturedArtists(): Promise<Artist[]> {
 export async function FeaturedArtists() {
   const artists = await getFeaturedArtists();
 
-  return (
-    <section className="w-full py-12">
-      <div className="w-full overflow-x-auto">
-        <div className="flex flex-row gap-6 justify-center md:justify-between w-full min-w-[600px]">
-          {artists.length > 0 ? (
-            artists.map((artist) => (
-              <Link
-                key={artist.id}
-                href={`/${artist.handle}`}
-                className="group flex items-center justify-center"
-                title={artist.name}
-              >
-                <div className="relative">
-                  <OptimizedImage
-                    src={artist.image_url}
-                    alt={`${artist.name} - Music Artist`}
-                    size="lg"
-                    shape="circle"
-                    className="ring-2 ring-gray-300 dark:ring-white/20 group-hover:ring-gray-400 dark:group-hover:ring-white/40 transition-all duration-200"
-                  />
+  if (artists.length === 0) {
+    return (
+      <section
+        data-testid="featured-artists"
+        aria-label="Featured artists"
+        className="w-full py-12"
+      >
+        <p className="text-center text-sm text-gray-500 dark:text-white/60">
+          No featured artists yet. Check back soon.
+        </p>
+      </section>
+    );
+  }
 
-                  {/* Hover overlay with artist name */}
-                  <div className="absolute inset-0 flex items-center justify-center bg-black/50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                    <span className="text-white text-xs font-medium text-center px-2">
-                      {artist.name}
-                    </span>
-                  </div>
+  return (
+    <section
+      data-testid="featured-artists"
+      aria-label="Featured artists"
+      className="w-full py-12"
+    >
+      <ul className="flex w-full overflow-x-auto gap-6 justify-center md:justify-between scroll-smooth">
+        {artists.map((artist) => (
+          <li key={artist.id} className="flex-shrink-0">
+            <Link
+              href={`/${artist.handle}`}
+              className="group block focus:outline-none"
+              aria-label={`View ${artist.name}'s profile`}
+            >
+              <div className="relative">
+                <OptimizedImage
+                  src={artist.image_url}
+                  alt={`${artist.name} - Music Artist`}
+                  size="lg"
+                  shape="circle"
+                  className="ring-2 ring-gray-300 dark:ring-white/20 group-hover:ring-gray-400 dark:group-hover:ring-white/40 group-focus-visible:ring-gray-400 dark:group-focus-visible:ring-white/40 transition-all duration-200"
+                />
+
+                {/* Hover overlay with artist name */}
+                <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100">
+                  <span className="px-2 text-center text-xs font-medium text-white">
+                    {artist.name}
+                  </span>
                 </div>
-              </Link>
-            ))
-          ) : (
-            // Fallback if no artists are found
-            <div className="flex items-center justify-center w-full">
-              <div className="text-gray-500 dark:text-white/60 text-sm">
-                No artists available
               </div>
-            </div>
-          )}
-        </div>
-      </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- refine FeaturedArtists with accessible semantics and polished hover states
- add graceful empty state copy

## Testing
- `npm run lint -- --file components/home/FeaturedArtists.tsx --file tests/unit/FeaturedArtists.test.tsx`
- `npm test tests/unit/FeaturedArtists.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6896961c125c8327ba3c36a2c4c9c507