### PR TITLE
Add /api/health JSON endpoint for smoke tests on Preview

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    time: new Date().toISOString(),
+    env: process.env.VERCEL_ENV || 'local',
+    branch: process.env.VERCEL_GIT_COMMIT_REF || process.env.GIT_BRANCH || null,
+    commit: process.env.VERCEL_GIT_COMMIT_SHA || process.env.GIT_SHA || null,
+  });
+}


### PR DESCRIPTION
This PR adds a minimal health endpoint at `app/api/health/route.ts` that returns JSON:

```
{
  status: 'ok',
  time: <iso>,
  env: <vercel env>,
  branch: <git ref>,
  commit: <git sha>
}
```

Context:
- Our Playwright smoke suite runs against the Preview alias (BASE_URL=https://preview.jov.ie) and asserts `/api/health` returns `{ status: 'ok' }`.
- Preview currently responds 404 HTML for `/api/health`, causing JSON parse errors in the smoke test.
- This PR resolves that by adding the route so Preview serves JSON.

No functional app impact; this is purely for observability/health and automation. Once merged and deployed, the smoke tests should pass against the Preview domain.