### PR TITLE
fix(flags): Edge runtime + dynamic for /.well-known/vercel/flags to resolve Preview 400

### DIFF
--- a/app/.well-known/vercel/flags/route.ts
+++ b/app/.well-known/vercel/flags/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
 
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 // Vercel Flags v4 discovery endpoint
 // Returns versioned flag definitions so the Toolbar/Flags Explorer can detect the SDK
 export async function GET() {
-  // Enable debug banner in development by default
-  const isDevelopment = process.env.NODE_ENV === 'development';
+  // Discovery endpoint returns static defaults (no env branching)
 
   const response = {
     version: 4,


### PR DESCRIPTION
Summary

Serve the Vercel Flags discovery endpoint from the Edge runtime and force dynamic/no-cache. This aims to resolve the Preview-only `400 Bad Request` we observed for `/.well-known/vercel/flags` despite a correct static JSON payload.

Changes
- app/.well-known/vercel/flags/route.ts
  - export const runtime = 'edge'
  - export const dynamic = 'force-dynamic'
  - export const revalidate = 0
  - keep `Cache-Control: no-store` and v4 payload

Why
- Some Vercel environments (Preview) can return 400 on `.well-known` when served via Node runtime + caching. Edge + dynamic avoids caching and aligns with Vercel Toolbar/Flags expectations.

Validation
- Local: route returns 200, proper `content-type`, version 4, flags present, `Cache-Control: no-store`.
- Existing tests: `tests/api/flags.test.ts` already asserts the above.

Next
- Let CI deploy to Preview
- Verify https://preview.jov.ie/.well-known/vercel/flags returns 200 with version: 4
- If still failing, we will inspect headers via `curl -v` on the Preview URL and adjust middleware/headers accordingly.
