### PR TITLE
Add stories for dashboard atoms

### DIFF
--- a/components/dashboard/atoms/SortableLinkItem.stories.tsx
+++ b/components/dashboard/atoms/SortableLinkItem.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { SortableLinkItem } from './SortableLinkItem';
+import {
+  detectPlatform,
+  type DetectedLink,
+} from '@/lib/utils/platform-detection';
+
+interface LinkItem extends DetectedLink {
+  id: string;
+  title: string;
+  isVisible: boolean;
+  order: number;
+}
+
+const detected = detectPlatform('https://open.spotify.com/artist/123');
+
+const defaultLink: LinkItem = {
+  ...detected,
+  id: '1',
+  title: 'Spotify',
+  isVisible: true,
+  order: 0,
+};
+
+const meta: Meta<typeof SortableLinkItem> = {
+  title: 'Dashboard/Atoms/SortableLinkItem',
+  component: SortableLinkItem,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Wrapper(args: LinkItemStoryProps) {
+  return (
+    <DndContext>
+      <SortableContext items={[args.link.id]}>
+        <SortableLinkItem {...args} />
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface LinkItemStoryProps {
+  link: LinkItem;
+  onUpdate: (id: string, updates: Partial<LinkItem>) => void;
+  onDelete: (id: string) => void;
+  disabled?: boolean;
+}
+
+export const Default: Story = {
+  render: Wrapper,
+  args: {
+    link: defaultLink,
+    onUpdate: () => {},
+    onDelete: () => {},
+  },
+};
+
+export const Hidden: Story = {
+  render: Wrapper,
+  args: {
+    link: { ...defaultLink, isVisible: false },
+    onUpdate: () => {},
+    onDelete: () => {},
+  },
+};
+
+export const Disabled: Story = {
+  render: Wrapper,
+  args: {
+    link: defaultLink,
+    onUpdate: () => {},
+    onDelete: () => {},
+    disabled: true,
+  },
+};

--- a/components/dashboard/atoms/UniversalLinkInput.stories.tsx
+++ b/components/dashboard/atoms/UniversalLinkInput.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UniversalLinkInput } from './UniversalLinkInput';
+
+const meta: Meta<typeof UniversalLinkInput> = {
+  title: 'Dashboard/Atoms/UniversalLinkInput',
+  component: UniversalLinkInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onAdd: () => {},
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    onAdd: () => {},
+    disabled: true,
+  },
+};
+
+export const CustomPlaceholder: Story = {
+  args: {
+    onAdd: () => {},
+    placeholder: 'Paste your link here',
+  },
+};


### PR DESCRIPTION
## Summary
- document SortableLinkItem with storybook examples
- document UniversalLinkInput with storybook stories

## Testing
- `npm run lint -- --file components/dashboard/atoms/SortableLinkItem.stories.tsx --file components/dashboard/atoms/UniversalLinkInput.stories.tsx`
- `npm test` *(fails: Not implemented navigation, window.alert, Playwright describe misuse, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d751d3588327958b8260b192f9f4