### PR TITLE
feat: optimize dashboard inputs for mobile

### DIFF
--- a/components/dashboard/atoms/SortableLinkItem.tsx
+++ b/components/dashboard/atoms/SortableLinkItem.tsx
@@ -143,6 +143,10 @@ export const SortableLinkItem: React.FC<SortableLinkItemProps> = ({
               onChange={handleTitleChange}
               onBlur={handleTitleSubmit}
               onKeyDown={handleTitleKeyPress}
+              inputMode="text"
+              autoCapitalize="words"
+              autoCorrect="on"
+              autoComplete="off"
               className="text-sm font-medium -my-1"
               autoFocus
             />

--- a/components/dashboard/atoms/UniversalLinkInput.tsx
+++ b/components/dashboard/atoms/UniversalLinkInput.tsx
@@ -94,6 +94,10 @@ export const UniversalLinkInput: React.FC<UniversalLinkInputProps> = ({
           onChange={handleUrlChange}
           onKeyPress={handleKeyPress}
           disabled={disabled}
+          inputMode="url"
+          autoCapitalize="none"
+          autoCorrect="off"
+          autoComplete="off"
           className="pr-24"
         />
 
@@ -166,6 +170,10 @@ export const UniversalLinkInput: React.FC<UniversalLinkInputProps> = ({
                 value={displayTitle}
                 onChange={handleTitleChange}
                 disabled={disabled}
+                inputMode="text"
+                autoCapitalize="words"
+                autoCorrect="on"
+                autoComplete="off"
                 className="text-sm mb-2"
               />
 

--- a/components/dashboard/molecules/AvatarUploader.tsx
+++ b/components/dashboard/molecules/AvatarUploader.tsx
@@ -119,7 +119,8 @@ export default function AvatarUploader({
             type="file"
             accept="image/*"
             onChange={onSelect}
-            className="block text-sm"
+            className="block text-sm cursor-pointer"
+            aria-label="Choose profile image"
           />
           <button
             type="button"

--- a/components/dashboard/organisms/ListenNowForm.tsx
+++ b/components/dashboard/organisms/ListenNowForm.tsx
@@ -77,6 +77,10 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
             setFormData({ ...formData, spotify_url: e.target.value })
           }
           placeholder="https://open.spotify.com/artist/..."
+          inputMode="url"
+          autoCapitalize="none"
+          autoCorrect="off"
+          autoComplete="off"
         />
       </FormField>
 
@@ -88,6 +92,10 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
             setFormData({ ...formData, apple_music_url: e.target.value })
           }
           placeholder="https://music.apple.com/..."
+          inputMode="url"
+          autoCapitalize="none"
+          autoCorrect="off"
+          autoComplete="off"
         />
       </FormField>
 
@@ -99,6 +107,10 @@ export function ListenNowForm({ artist, onUpdate }: ListenNowFormProps) {
             setFormData({ ...formData, youtube_url: e.target.value })
           }
           placeholder="https://youtube.com/..."
+          inputMode="url"
+          autoCapitalize="none"
+          autoCorrect="off"
+          autoComplete="off"
         />
       </FormField>
 

--- a/components/dashboard/organisms/OnboardingForm.tsx
+++ b/components/dashboard/organisms/OnboardingForm.tsx
@@ -371,6 +371,10 @@ export function OnboardingForm() {
                 handleError || handleValidation.error ? 'true' : 'false'
               }
               aria-label="Enter your desired handle"
+              autoCapitalize="none"
+              autoCorrect="off"
+              autoComplete="off"
+              inputMode="text"
             />
             {handleValidation.checking && (
               <div className="absolute right-3 top-1/2 transform -translate-y-1/2">

--- a/components/dashboard/organisms/ProfileForm.tsx
+++ b/components/dashboard/organisms/ProfileForm.tsx
@@ -116,6 +116,9 @@ export function ProfileForm({ artist, onUpdate }: ProfileFormProps) {
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           placeholder="Your Artist Name"
           required
+          autoCapitalize="words"
+          autoCorrect="on"
+          autoComplete="name"
         />
       </FormField>
 
@@ -128,6 +131,9 @@ export function ProfileForm({ artist, onUpdate }: ProfileFormProps) {
             setFormData({ ...formData, tagline: e.target.value })
           }
           placeholder="Share your story, music journey, or what inspires you..."
+          autoCapitalize="sentences"
+          autoCorrect="on"
+          autoComplete="off"
         />
       </FormField>
 

--- a/components/dashboard/organisms/SettingsForm.tsx
+++ b/components/dashboard/organisms/SettingsForm.tsx
@@ -71,7 +71,8 @@ export function SettingsForm({ artist, onUpdate }: SettingsFormProps) {
                 checked={marketingOptOut}
                 onChange={(e) => handleMarketingOptOutChange(e.target.checked)}
                 disabled={isUpdating}
-                className="w-4 h-4 text-indigo-600 bg-gray-100 border-gray-300 rounded focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 disabled:opacity-50"
+                aria-label="Opt out of marketing materials"
+                className="w-5 h-5 text-indigo-600 bg-gray-100 border-gray-300 rounded focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600 disabled:opacity-50"
               />
             </div>
             <div className="text-sm">

--- a/components/dashboard/organisms/SocialsForm.tsx
+++ b/components/dashboard/organisms/SocialsForm.tsx
@@ -198,6 +198,10 @@ export function SocialsForm({ artist }: SocialsFormProps) {
                 value={link.url}
                 onChange={(e) => updateSocialLink(index, 'url', e.target.value)}
                 placeholder="https://..."
+                inputMode="url"
+                autoCapitalize="none"
+                autoCorrect="off"
+                autoComplete="off"
                 className="flex-1"
               />
 


### PR DESCRIPTION
## Summary
- refine universal link and title inputs with mobile-friendly attributes
- improve dashboard forms with URL-specific input modes and autocorrect controls
- enhance settings and profile fields for better touch targets and accessibility

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Property 'signIn' does not exist on type 'Clerk', etc.)*
- `npm test` *(fails: Not implemented: navigation (except hash changes))*

------
https://chatgpt.com/codex/tasks/task_e_68a6d8c09e88832797eda5c77a4013be