### PR TITLE
feat: prefetch artist profile modes for faster navigation

### DIFF
--- a/components/organisms/ProfileShell.tsx
+++ b/components/organisms/ProfileShell.tsx
@@ -132,6 +132,7 @@ export function ProfileShell({
                     <div className="flex-shrink-0">
                       <Link
                         href={`/${artist.handle}?mode=tip`}
+                        prefetch
                         className="inline-flex items-center px-3 py-1.5 bg-white/10 hover:bg-white/20 dark:bg-white/5 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 font-medium text-xs rounded-full transition-all duration-200 border border-gray-200/30 dark:border-white/10 backdrop-blur-sm cursor-pointer"
                       >
                         <span className="mr-1.5 text-xs">💸</span>

--- a/components/profile/AnimatedArtistPage.tsx
+++ b/components/profile/AnimatedArtistPage.tsx
@@ -90,6 +90,7 @@ function renderContent(
           <div className="space-y-4">
             <Link
               href={`/${artist.handle}?mode=listen`}
+              prefetch
               className="inline-flex items-center justify-center w-full px-8 py-4 text-lg font-semibold text-white bg-black hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-100 rounded-xl transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white focus:ring-offset-2"
             >
               🎵 Listen Now

--- a/components/profile/ProgressiveArtistPage.tsx
+++ b/components/profile/ProgressiveArtistPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { StaticArtistPage } from '@/components/profile/StaticArtistPage';
 import { Artist, LegacySocialLink } from '@/types/db';
 import dynamic from 'next/dynamic';
@@ -28,6 +29,19 @@ interface ProgressiveArtistPageProps {
 
 export function ProgressiveArtistPage(props: ProgressiveArtistPageProps) {
   const [shouldUseAnimated, setShouldUseAnimated] = useState(false);
+  const router = useRouter();
+
+  // Prefetch all artist modes for snappy transitions
+  useEffect(() => {
+    const base = `/${props.artist.handle}`;
+    ['profile', 'listen', 'tip']
+      .filter((m) => m !== props.mode)
+      .forEach((mode) => {
+        const searchUrl = mode === 'profile' ? base : `${base}?mode=${mode}`;
+        router.prefetch(searchUrl);
+        router.prefetch(`${base}/${mode}`);
+      });
+  }, [router, props.artist.handle, props.mode]);
 
   useEffect(() => {
     // For listen mode, stay with static version for better performance

--- a/components/profile/StaticArtistPage.tsx
+++ b/components/profile/StaticArtistPage.tsx
@@ -75,6 +75,7 @@ function renderContent(
         <div className="space-y-4">
           <Link
             href={`/${artist.handle}?mode=listen`}
+            prefetch
             className="inline-flex items-center justify-center w-full px-8 py-4 text-lg font-semibold text-white bg-black hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-100 rounded-xl transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white focus:ring-offset-2"
           >
             🎵 Listen Now


### PR DESCRIPTION
## Summary
- prefetch alternate modes on artist pages for instant transitions
- enable link prefetching for listen and tip views

## Testing
- `npm run lint`
- `npm test` *(fails: 3 failed, 268 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d8e263148327a3fb59b4671f1153