### PR TITLE
Potential fix for code scanning alert no. 49: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/app/api/images/sign-upload/route.ts
+++ b/app/api/images/sign-upload/route.ts
@@ -21,7 +21,7 @@ function signParams(
     .join('&');
 
   const signature = crypto
-    .createHash('sha1')
+    .createHash('sha256')
     .update(`${toSign}${env.CLOUDINARY_API_SECRET ?? ''}`)
     .digest('hex');
 


### PR DESCRIPTION
Potential fix for [https://github.com/itstimwhite/Jovie/security/code-scanning/49](https://github.com/itstimwhite/Jovie/security/code-scanning/49)

To fix the problem, update the cryptographic hash function from SHA-1 to a stronger algorithm such as SHA-256. This will strengthen the security of the signature by making it resistant to collision attacks. Specifically, in `app/api/images/sign-upload/route.ts`, update the call to `crypto.createHash('sha1')` to `crypto.createHash('sha256')`. No other functionality needs to change. After replacing SHA-1 with SHA-256, verify that Cloudinary’s API accepts SHA-256-based signatures; if not, document the reason for retaining SHA-1 and revisit when Cloudinary supports stronger signatures. The only required code change is the hash algorithm name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
